### PR TITLE
ci(actions): harden repository automation

### DIFF
--- a/.agents/specs/2026-07-29-repository-automation.md
+++ b/.agents/specs/2026-07-29-repository-automation.md
@@ -9,34 +9,41 @@ Audit the active workflows against `fastypest`, harden cache and Dependabot auto
 - Default branch: `main`.
 - Stack: pnpm, Node.js, TypeScript, and multiple database test services.
 - The repository is actively maintained through Dependabot and release PRs.
-- Existing cache cleanup is shell-specific and not empty-safe.
-- Existing `pull_request_target` automation checks out PR code and uses mutable Action tags.
-- `auto-release.workflow.yml` creates an owner-authored PR labeled `auto-release`, waits for a GitHub Actions approval, runs checks, merges, and publishes the npm package.
+- Existing cache cleanup was shell-specific and not empty-safe.
+- Existing `pull_request_target` automation checked out PR code and used mutable Action tags.
+- Dependabot-triggered `pull_request_target` workflows receive a read-only token and no secrets, so privileged Dependabot automation must not depend on repository secrets.
+- `auto-release.workflow.yml` owns the existing npm publication contract and already uses its established credentials.
 
 ## Decision
 
 - Group weekly npm and GitHub Actions updates after a seven-day cooldown.
 - Replace cache deletion with a generic API workflow and manual dry-run by default.
-- Remove checkout and PR-controlled execution from privileged automation; pin introduced Actions by immutable SHA.
-- Preserve the trusted `auto-release` approval job so the existing release workflow is not broken.
-- Auto-approve patch/minor updates and development-only majors. Production majors require a current approval from a reviewer with repository write permission.
+- Use `pull_request` plus the repository-scoped `GITHUB_TOKEN` for Dependabot approval, labels, and auto-merge; no PR code is checked out.
+- Preserve the trusted `auto-release` PR approval job using the repository-scoped `GITHUB_TOKEN`.
+- Require a current write-permission maintainer approval for production majors, bound to the current head SHA.
+- Use the scheduled default-branch workflow and `GITHUB_TOKEN` for required-QA branch updates and auto-merge.
 - Leave `auto-release.workflow.yml` unchanged: this PR neither copies nor removes npm publication behavior.
 
 ## Acceptance
 
 - [x] Existing release approval behavior remains available.
-- [x] No privileged workflow executes pull-request-controlled code.
+- [x] No privileged workflow checks out pull-request-controlled code.
 - [x] External or stale approvals cannot unlock production majors.
 - [x] Cache cleanup is global and empty-safe.
+- [x] No new repository secret or variable is required by this PR.
 - [x] No release, npm publication, deployment, or merge is performed by this task.
 
 ## Validation
 
 The proposed YAML parsed successfully. Dependabot, cache, required-QA, CI, package, and release contracts were inspected. Pull-request CI remains the runtime gate.
 
+## Repository settings
+
+Enable repository auto-merge and `Allow GitHub Actions to create and approve pull requests`. Required status checks must remain enforced on `main`. Existing release credentials remain governed by `auto-release.workflow.yml` and are not changed here.
+
 ## Risks and rollback
 
-GitHub Actions approvals, auto-merge, branch protection, and the automation token must remain configured consistently with the release workflow. The existing npm release workflow retains separate legacy security debt. Revert this PR to roll back; no package or runtime data requires recovery.
+The new dependency workflows cannot approve or queue pull requests if the repository settings above are disabled. The existing npm release workflow retains separate legacy security debt. Revert this PR to roll back; no package or runtime data requires recovery.
 
 ## Delivery
 

--- a/.agents/specs/2026-07-29-repository-automation.md
+++ b/.agents/specs/2026-07-29-repository-automation.md
@@ -1,0 +1,49 @@
+# Repository automation standardization
+
+## Request
+
+Audit the active workflows against `fastypest`, harden cache and Dependabot automation, preserve the package release contract, and open one PR without merging or publishing.
+
+## Evidence
+
+- Default branch: `main`.
+- Stack: pnpm, Node.js, TypeScript, and multiple database test services.
+- The repository is actively maintained through Dependabot and release PRs.
+- Existing cache cleanup is shell-specific and not empty-safe.
+- Existing `pull_request_target` automation checks out PR code and uses mutable Action tags.
+- `auto-release.workflow.yml` creates an owner-authored PR labeled `auto-release`, waits for a GitHub Actions approval, runs checks, merges, and publishes the npm package.
+
+## Decision
+
+- Group weekly npm and GitHub Actions updates after a seven-day cooldown.
+- Replace cache deletion with a generic API workflow and manual dry-run by default.
+- Remove checkout and PR-controlled execution from privileged automation; pin introduced Actions by immutable SHA.
+- Preserve the trusted `auto-release` approval job so the existing release workflow is not broken.
+- Auto-approve patch/minor updates and development-only majors. Production majors require a current approval from a reviewer with repository write permission.
+- Leave `auto-release.workflow.yml` unchanged: this PR neither copies nor removes npm publication behavior.
+
+## Acceptance
+
+- [x] Existing release approval behavior remains available.
+- [x] No privileged workflow executes pull-request-controlled code.
+- [x] External or stale approvals cannot unlock production majors.
+- [x] Cache cleanup is global and empty-safe.
+- [x] No release, npm publication, deployment, or merge is performed by this task.
+
+## Validation
+
+The proposed YAML parsed successfully. Dependabot, cache, required-QA, CI, package, and release contracts were inspected. Pull-request CI remains the runtime gate.
+
+## Risks and rollback
+
+GitHub Actions approvals, auto-merge, branch protection, and the automation token must remain configured consistently with the release workflow. The existing npm release workflow retains separate legacy security debt. Revert this PR to roll back; no package or runtime data requires recovery.
+
+## Delivery
+
+- Branch: `agent/chore-repository-automation`
+- Base: `main`
+- Merge/release/deploy/publish: not authorized
+
+## Status
+
+Implemented on the task branch; pull-request checks and repository settings remain to be verified.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,18 +3,41 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "tuesday"
       time: "07:00"
       timezone: "Europe/Madrid"
     versioning-strategy: "increase-if-necessary"
-    target-branch: "main"
-    rebase-strategy: auto
-
+    rebase-strategy: "auto"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      production-minor-patch:
+        patterns: ["*"]
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      development-minor-patch:
+        patterns: ["*"]
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
       time: "07:00"
       timezone: "Europe/Madrid"
-    target-branch: "main"
-    rebase-strategy: auto
+    rebase-strategy: "auto"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps-actions)"
+    groups:
+      actions-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -19,46 +19,44 @@ concurrency:
 
 jobs:
   process:
+    name: Process approved Dependabot majors
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
-      pull-requests: read
-    env:
-      AUTOMATION_TOKEN: ${{ secrets.REPOSITORY_AUTOMATION_TOKEN || secrets.PAT_FINE }}
+      contents: write
+      pull-requests: write
     steps:
-      - name: Explain missing automation token
-        if: env.AUTOMATION_TOKEN == ''
-        run: echo "::notice title=Repository automation token missing::Configure REPOSITORY_AUTOMATION_TOKEN or PAT_FINE to enable branch updates and auto-merge."
-
       - name: Validate current approvals and enable auto-merge
-        if: env.AUTOMATION_TOKEN != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           DRY_RUN: ${{ inputs.dry_run || false }}
         with:
-          github-token: ${{ env.AUTOMATION_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const dryRun = process.env.DRY_RUN === 'true';
             const { owner, repo } = context.repo;
             const defaultBranch = context.payload.repository.default_branch;
-            const pulls = await github.paginate(github.rest.pulls.list, {
-              owner,
-              repo,
-              state: 'open',
-              per_page: 100,
-            });
-            const candidates = pulls.filter(
-              (pr) =>
-                pr.user?.login === 'dependabot[bot]' &&
-                pr.base.ref === defaultBranch &&
-                pr.head.repo?.full_name === `${owner}/${repo}` &&
-                pr.labels.some((label) => label.name === 'requires-manual-qa'),
+            const pullRequests = await github.paginate(
+              github.rest.pulls.list,
+              { owner, repo, state: 'open', per_page: 100 },
+            );
+
+            const candidates = pullRequests.filter(
+              (pullRequest) =>
+                pullRequest.user?.login === 'dependabot[bot]' &&
+                pullRequest.base.ref === defaultBranch &&
+                pullRequest.head.repo?.full_name === `${owner}/${repo}` &&
+                pullRequest.labels.some(
+                  (label) => label.name === 'requires-manual-qa',
+                ),
             );
 
             const permissionCache = new Map();
-            const canApprove = async (login) => {
-              if (permissionCache.has(login)) return permissionCache.get(login);
+            const hasWritePermission = async (login) => {
+              if (permissionCache.has(login)) {
+                return permissionCache.get(login);
+              }
+
               try {
                 const response =
                   await github.rest.repos.getCollaboratorPermissionLevel({
@@ -72,7 +70,10 @@ jobs:
                 permissionCache.set(login, allowed);
                 return allowed;
               } catch (error) {
-                if (error.status === 404) return false;
+                if (error.status === 404) {
+                  permissionCache.set(login, false);
+                  return false;
+                }
                 throw error;
               }
             };
@@ -95,6 +96,7 @@ jobs:
                   });
                   continue;
                 }
+
                 await github.rest.pulls.updateBranch({
                   owner,
                   repo,
@@ -113,7 +115,8 @@ jobs:
                 github.rest.pulls.listReviews,
                 { owner, repo, pull_number: candidate.number, per_page: 100 },
               );
-              const latestByUser = new Map();
+              const latestReviewByUser = new Map();
+
               for (const review of reviews) {
                 const login = review.user?.login;
                 const submittedAt = Date.parse(review.submitted_at ?? '');
@@ -124,9 +127,10 @@ jobs:
                 ) {
                   continue;
                 }
-                const previous = latestByUser.get(login);
+
+                const previous = latestReviewByUser.get(login);
                 if (!previous || submittedAt > previous.submittedAt) {
-                  latestByUser.set(login, {
+                  latestReviewByUser.set(login, {
                     state: review.state,
                     submittedAt,
                   });
@@ -135,11 +139,17 @@ jobs:
 
               let approved = false;
               let changesRequested = false;
-              for (const [login, review] of latestByUser) {
-                if (login.endsWith('[bot]') || !(await canApprove(login))) continue;
+              for (const [login, review] of latestReviewByUser) {
+                if (
+                  login.endsWith('[bot]') ||
+                  !(await hasWritePermission(login))
+                ) {
+                  continue;
+                }
                 approved ||= review.state === 'APPROVED';
                 changesRequested ||= review.state === 'CHANGES_REQUESTED';
               }
+
               if (!approved || changesRequested) {
                 results.push({
                   number: candidate.number,
@@ -150,6 +160,7 @@ jobs:
                 });
                 continue;
               }
+
               if (dryRun) {
                 results.push({
                   number: candidate.number,
@@ -171,18 +182,32 @@ jobs:
                 });
                 continue;
               }
+
               if (!verified.data.auto_merge) {
                 await github.graphql(
-                  `mutation($id: ID!, $head: GitObjectID!) {
-                    enablePullRequestAutoMerge(input: {
-                      pullRequestId: $id
-                      mergeMethod: SQUASH
-                      expectedHeadOid: $head
-                    }) { pullRequest { number } }
+                  `mutation EnableAutoMerge(
+                    $pullRequestId: ID!
+                    $expectedHeadOid: GitObjectID!
+                  ) {
+                    enablePullRequestAutoMerge(
+                      input: {
+                        pullRequestId: $pullRequestId
+                        mergeMethod: SQUASH
+                        expectedHeadOid: $expectedHeadOid
+                      }
+                    ) {
+                      pullRequest {
+                        number
+                      }
+                    }
                   }`,
-                  { id: verified.data.node_id, head: currentHeadSha },
+                  {
+                    pullRequestId: verified.data.node_id,
+                    expectedHeadOid: currentHeadSha,
+                  },
                 );
               }
+
               results.push({
                 number: candidate.number,
                 action: 'auto-merge-enabled',
@@ -192,14 +217,14 @@ jobs:
             await core.summary
               .addHeading('Required QA auto-merge')
               .addRaw(
-                results.length
-                  ? results
+                results.length === 0
+                  ? 'No eligible Dependabot pull requests found.'
+                  : results
                       .map(
                         (result) =>
                           `- #${result.number}: ${result.action}` +
                           `${result.reason ? ` — ${result.reason}` : ''}`,
                       )
-                      .join('\n')
-                  : 'No eligible Dependabot pull requests found.',
+                      .join('\n'),
               )
               .write();

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -12,6 +12,7 @@ on:
         type: boolean
 
 permissions: read-all
+
 concurrency:
   group: required-qa-auto-merge
   cancel-in-progress: false
@@ -21,30 +22,53 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
+    env:
+      AUTOMATION_TOKEN: ${{ secrets.REPOSITORY_AUTOMATION_TOKEN || secrets.PAT_FINE }}
     steps:
-      - name: Validate maintainer approvals and enable auto-merge
+      - name: Explain missing automation token
+        if: env.AUTOMATION_TOKEN == ''
+        run: echo "::notice title=Repository automation token missing::Configure REPOSITORY_AUTOMATION_TOKEN or PAT_FINE to enable branch updates and auto-merge."
+
+      - name: Validate current approvals and enable auto-merge
+        if: env.AUTOMATION_TOKEN != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           DRY_RUN: ${{ inputs.dry_run || false }}
         with:
+          github-token: ${{ env.AUTOMATION_TOKEN }}
           script: |
             const dryRun = process.env.DRY_RUN === 'true';
             const { owner, repo } = context.repo;
-            const pulls = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 });
-            const candidates = pulls.filter((pr) =>
-              pr.user?.login === 'dependabot[bot]' &&
-              pr.base.ref === context.payload.repository.default_branch &&
-              pr.head.repo?.full_name === `${owner}/${repo}` &&
-              pr.labels.some((label) => label.name === 'requires-manual-qa'),
+            const defaultBranch = context.payload.repository.default_branch;
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const candidates = pulls.filter(
+              (pr) =>
+                pr.user?.login === 'dependabot[bot]' &&
+                pr.base.ref === defaultBranch &&
+                pr.head.repo?.full_name === `${owner}/${repo}` &&
+                pr.labels.some((label) => label.name === 'requires-manual-qa'),
             );
+
             const permissionCache = new Map();
             const canApprove = async (login) => {
               if (permissionCache.has(login)) return permissionCache.get(login);
               try {
-                const response = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username: login });
-                const allowed = ['admin', 'maintain', 'write'].includes(response.data.permission);
+                const response =
+                  await github.rest.repos.getCollaboratorPermissionLevel({
+                    owner,
+                    repo,
+                    username: login,
+                  });
+                const allowed = ['admin', 'maintain', 'write'].includes(
+                  response.data.permission,
+                );
                 permissionCache.set(login, allowed);
                 return allowed;
               } catch (error) {
@@ -52,38 +76,130 @@ jobs:
                 throw error;
               }
             };
+
             const results = [];
             for (const candidate of candidates) {
-              const reviews = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number: candidate.number, per_page: 100 });
-              const latest = new Map();
+              const current = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: candidate.number,
+              });
+              const currentHeadSha = current.data.head.sha;
+
+              if (current.data.mergeable_state === 'behind') {
+                if (dryRun) {
+                  results.push({
+                    number: candidate.number,
+                    action: 'would-update-branch',
+                    reason: 'fresh approval required after the update',
+                  });
+                  continue;
+                }
+                await github.rest.pulls.updateBranch({
+                  owner,
+                  repo,
+                  pull_number: candidate.number,
+                  expected_head_sha: currentHeadSha,
+                });
+                results.push({
+                  number: candidate.number,
+                  action: 'branch-update-requested',
+                  reason: 'fresh approval required for the new head commit',
+                });
+                continue;
+              }
+
+              const reviews = await github.paginate(
+                github.rest.pulls.listReviews,
+                { owner, repo, pull_number: candidate.number, per_page: 100 },
+              );
+              const latestByUser = new Map();
               for (const review of reviews) {
                 const login = review.user?.login;
                 const submittedAt = Date.parse(review.submitted_at ?? '');
-                if (!login || !Number.isFinite(submittedAt)) continue;
-                const previous = latest.get(login);
-                if (!previous || submittedAt > previous.submittedAt) latest.set(login, { state: review.state, submittedAt });
+                if (
+                  !login ||
+                  !Number.isFinite(submittedAt) ||
+                  review.commit_id !== currentHeadSha
+                ) {
+                  continue;
+                }
+                const previous = latestByUser.get(login);
+                if (!previous || submittedAt > previous.submittedAt) {
+                  latestByUser.set(login, {
+                    state: review.state,
+                    submittedAt,
+                  });
+                }
               }
+
               let approved = false;
               let changesRequested = false;
-              for (const [login, review] of latest) {
+              for (const [login, review] of latestByUser) {
                 if (login.endsWith('[bot]') || !(await canApprove(login))) continue;
                 approved ||= review.state === 'APPROVED';
                 changesRequested ||= review.state === 'CHANGES_REQUESTED';
               }
-              if (!approved || changesRequested) { results.push({ number: candidate.number, action: 'skipped' }); continue; }
-              if (dryRun) { results.push({ number: candidate.number, action: 'would-enable-auto-merge' }); continue; }
-              const current = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
-              if (current.data.mergeable_state === 'behind') {
-                await github.rest.pulls.updateBranch({ owner, repo, pull_number: candidate.number, expected_head_sha: current.data.head.sha });
+              if (!approved || changesRequested) {
+                results.push({
+                  number: candidate.number,
+                  action: 'skipped',
+                  reason: changesRequested
+                    ? 'current maintainer review requests changes'
+                    : 'no maintainer approval for the current head commit',
+                });
+                continue;
               }
-              if (!current.data.auto_merge) {
+              if (dryRun) {
+                results.push({
+                  number: candidate.number,
+                  action: 'would-enable-auto-merge',
+                });
+                continue;
+              }
+
+              const verified = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: candidate.number,
+              });
+              if (verified.data.head.sha !== currentHeadSha) {
+                results.push({
+                  number: candidate.number,
+                  action: 'skipped',
+                  reason: 'head commit changed during validation',
+                });
+                continue;
+              }
+              if (!verified.data.auto_merge) {
                 await github.graphql(
-                  `mutation($id: ID!) { enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: SQUASH }) { pullRequest { number } } }`,
-                  { id: current.data.node_id },
+                  `mutation($id: ID!, $head: GitObjectID!) {
+                    enablePullRequestAutoMerge(input: {
+                      pullRequestId: $id
+                      mergeMethod: SQUASH
+                      expectedHeadOid: $head
+                    }) { pullRequest { number } }
+                  }`,
+                  { id: verified.data.node_id, head: currentHeadSha },
                 );
               }
-              results.push({ number: candidate.number, action: 'auto-merge-enabled' });
+              results.push({
+                number: candidate.number,
+                action: 'auto-merge-enabled',
+              });
             }
-            await core.summary.addHeading('Required QA auto-merge').addRaw(
-              results.length ? results.map((result) => `- #${result.number}: ${result.action}`).join('\n') : 'No eligible Dependabot pull requests found.',
-            ).write();
+
+            await core.summary
+              .addHeading('Required QA auto-merge')
+              .addRaw(
+                results.length
+                  ? results
+                      .map(
+                        (result) =>
+                          `- #${result.number}: ${result.action}` +
+                          `${result.reason ? ` — ${result.reason}` : ''}`,
+                      )
+                      .join('\n')
+                  : 'No eligible Dependabot pull requests found.',
+              )
+              .write();

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -1,4 +1,4 @@
-name: 🔄 PRs Required QA Auto-Merge
+name: 🔄 Required QA auto-merge
 
 on:
   schedule:
@@ -6,155 +6,84 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Do not actually merge, just simulate (for testing)"
-        required: false
-        default: "false"
-        type: choice
-        options:
-          - "true"
-          - "false"
+        description: Report eligible pull requests without enabling auto-merge
+        required: true
+        default: true
+        type: boolean
 
-run-name: 🔄 PRs Required QA Auto-Merge${{ github.event.inputs.dry_run == 'true' && ' (dry)' || '' }}
-
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
+concurrency:
+  group: required-qa-auto-merge
+  cancel-in-progress: false
 
 jobs:
-  auto-merge-required-qa:
-    if: github.actor == github.repository_owner || github.actor == 'github-actions'
-    name: Auto merge required QA${{ github.event.inputs.dry_run == 'true' && ' (dry)' || '' }}
+  process:
     runs-on: ubuntu-latest
-    environment: admin
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v6
-
-      - name: 🔍 Search PRs requires-manual-qa
-        id: search_prs
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prs = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 100
-            });
-            // Filter by label, dependabot and base main
-            const filtered = prs.data.filter(pr =>
-              pr.labels.some(l => l.name === 'requires-manual-qa') &&
-              pr.user.login === 'dependabot[bot]' &&
-              pr.base.ref === 'main' &&
-              pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`
-            );
-            return filtered.map(pr => pr.number);
-
-      - name: 🤖 Process PRs
-        if: steps.search_prs.outputs.result != '[]'
-        uses: actions/github-script@v8
+      - name: Validate maintainer approvals and enable auto-merge
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          dry_run: ${{ github.event.inputs.dry_run }}
-          GH_TOKEN: ${{ secrets.PAT_FINE }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
         with:
-          github-token: ${{ secrets.PAT_FINE }}
           script: |
-            const dryRun = process.env.dry_run === 'true';
-            console.log(`Dry run mode: ${dryRun}`);
-
-            let prNumbers = ${{ steps.search_prs.outputs.result }};
-            if (typeof prNumbers === 'string') {
+            const dryRun = process.env.DRY_RUN === 'true';
+            const { owner, repo } = context.repo;
+            const pulls = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 });
+            const candidates = pulls.filter((pr) =>
+              pr.user?.login === 'dependabot[bot]' &&
+              pr.base.ref === context.payload.repository.default_branch &&
+              pr.head.repo?.full_name === `${owner}/${repo}` &&
+              pr.labels.some((label) => label.name === 'requires-manual-qa'),
+            );
+            const permissionCache = new Map();
+            const canApprove = async (login) => {
+              if (permissionCache.has(login)) return permissionCache.get(login);
               try {
-                prNumbers = JSON.parse(prNumbers);
-              } catch {
-                prNumbers = [];
+                const response = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username: login });
+                const allowed = ['admin', 'maintain', 'write'].includes(response.data.permission);
+                permissionCache.set(login, allowed);
+                return allowed;
+              } catch (error) {
+                if (error.status === 404) return false;
+                throw error;
               }
-            }
+            };
             const results = [];
-
-            for (const prNumber of prNumbers) {
-              console.log(`PR #${prNumber}: Processing...`);
-
-              let pr = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-
-              // 1. Check if approved
-
-              console.log(`PR #${prNumber}: Checking if  is approved...`);
-              const reviews = await github.rest.pulls.listReviews({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-
-              const approved = reviews.data.some(r => r.state === 'APPROVED');
-              if (!approved) {
-                console.log(`PR #${prNumber}: is NOT approved.`);
-                results.push({prNumber, merged: false, reason: 'No approved'});
-                continue;
+            for (const candidate of candidates) {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number: candidate.number, per_page: 100 });
+              const latest = new Map();
+              for (const review of reviews) {
+                const login = review.user?.login;
+                const submittedAt = Date.parse(review.submitted_at ?? '');
+                if (!login || !Number.isFinite(submittedAt)) continue;
+                const previous = latest.get(login);
+                if (!previous || submittedAt > previous.submittedAt) latest.set(login, { state: review.state, submittedAt });
               }
-              console.log(`PR #${prNumber}: is approved.`);
-
-              // 2. Enable auto-merge
-              if (!dryRun) {
-                try {
-                  const result = await github.graphql(`
-                    mutation EnableAutoMerge($pullRequestId: ID!) {
-                      enablePullRequestAutoMerge(input: {
-                        pullRequestId: $pullRequestId,
-                        mergeMethod: SQUASH
-                      }) {
-                        pullRequest {
-                          number
-                          autoMergeRequest {
-                            enabledAt
-                            enabledBy {
-                              login
-                            }
-                          }
-                        }
-                      }
-                    }
-                  `, {
-                    pullRequestId: pr.data.node_id,
-                    headers: {
-                      Authorization: `token ${process.env.GH_TOKEN}`
-                    }
-                  });
-
-                  console.log(`PR #${prNumber}: Auto-merge enabled.`);
-                  results.push({ prNumber, merged: true, reason: 'Auto-merge enabled' });
-                } catch (e) {
-                  console.log(`PR #${prNumber}: Auto-merge failed: ${e.message}`);
-                  results.push({ prNumber, merged: false, reason: 'Auto-merge failed: ' + e.message });
-                }
-              } else {
-                console.log(`PR #${prNumber}: Dry run, auto-merge skipped.`);
-                results.push({ prNumber, merged: false, reason: 'Dry run: auto-merge skipped' });
+              let approved = false;
+              let changesRequested = false;
+              for (const [login, review] of latest) {
+                if (login.endsWith('[bot]') || !(await canApprove(login))) continue;
+                approved ||= review.state === 'APPROVED';
+                changesRequested ||= review.state === 'CHANGES_REQUESTED';
               }
-
-              // 3. Updated with main
-              let updated = pr.data.mergeable_state === 'clean';
-
-              if (!updated) {
-                console.log(`PR #${prNumber}: is NOT up-to-date. Attempting to update...`);
-                try {
-                  await github.rest.pulls.updateBranch({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    pull_number: prNumber
-                  });
-                  console.log(`PR #${prNumber}: update triggered.`);
-                } catch (e) {
-                  console.log(`PR #${prNumber}: update FAILED: ${e.message}`);
-                  results.push({prNumber, merged: false, reason: 'Could not update branch: ' + e.message});
-                  continue;
-                }
+              if (!approved || changesRequested) { results.push({ number: candidate.number, action: 'skipped' }); continue; }
+              if (dryRun) { results.push({ number: candidate.number, action: 'would-enable-auto-merge' }); continue; }
+              const current = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+              if (current.data.mergeable_state === 'behind') {
+                await github.rest.pulls.updateBranch({ owner, repo, pull_number: candidate.number, expected_head_sha: current.data.head.sha });
               }
+              if (!current.data.auto_merge) {
+                await github.graphql(
+                  `mutation($id: ID!) { enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: SQUASH }) { pullRequest { number } } }`,
+                  { id: current.data.node_id },
+                );
+              }
+              results.push({ number: candidate.number, action: 'auto-merge-enabled' });
             }
-            console.table(results);
-            return results;
+            await core.summary.addHeading('Required QA auto-merge').addRaw(
+              results.length ? results.map((result) => `- #${result.number}: ${result.action}`).join('\n') : 'No eligible Dependabot pull requests found.',
+            ).write();

--- a/.github/workflows/delete-cache.workflow.yml
+++ b/.github/workflows/delete-cache.workflow.yml
@@ -17,29 +17,34 @@ on:
         type: boolean
 
 permissions: read-all
+
 concurrency:
   group: cache-maintenance
   cancel-in-progress: false
 
 jobs:
   cleanup:
+    name: 🧹 Delete stale Actions caches
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       actions: write
       contents: read
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - name: Inspect and delete stale caches
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           STALE_DAYS: ${{ inputs.stale_days || '7' }}
           DRY_RUN: ${{ inputs.dry_run || false }}
         with:
           script: |
-            const staleDays = Number.parseInt(process.env.STALE_DAYS, 10);
-            if (!Number.isInteger(staleDays) || staleDays < 1 || staleDays > 90) {
+            const staleDaysInput = process.env.STALE_DAYS ?? '';
+            if (!/^(?:[1-9]|[1-8]\d|90)$/.test(staleDaysInput)) {
               core.setFailed('stale_days must be an integer between 1 and 90');
               return;
             }
+
+            const staleDays = Number(staleDaysInput);
             const dryRun = process.env.DRY_RUN === 'true';
             const cutoff = Date.now() - staleDays * 86400000;
             const { owner, repo } = context.repo;
@@ -48,14 +53,18 @@ jobs:
               { owner, repo, per_page: 100 },
               (response) => response.data.actions_caches ?? [],
             );
-            const stale = caches.filter((cache) => {
+            const staleCaches = caches.filter((cache) => {
               const lastAccessedAt = Date.parse(cache.last_accessed_at);
               return Number.isFinite(lastAccessedAt) && lastAccessedAt <= cutoff;
             });
+
             let deleted = 0;
-            for (const cache of stale) {
-              core.info(`${dryRun ? 'Would delete' : 'Deleting'} ${cache.id} (${cache.key})`);
+            for (const cache of staleCaches) {
+              core.info(
+                `${dryRun ? 'Would delete' : 'Deleting'} ${cache.id} (${cache.key})`,
+              );
               if (dryRun) continue;
+
               try {
                 await github.request(
                   'DELETE /repos/{owner}/{repo}/actions/caches/{cache_id}',
@@ -67,11 +76,18 @@ jobs:
                 throw error;
               }
             }
-            await core.summary.addHeading('Actions cache maintenance').addTable([
-              [{ data: 'Metric', header: true }, { data: 'Value', header: true }],
-              ['Inspected', String(caches.length)],
-              ['Matched', String(stale.length)],
-              ['Deleted', String(deleted)],
-              ['Dry run', String(dryRun)],
-              ['Threshold', `${staleDays} days`],
-            ]).write();
+
+            await core.summary
+              .addHeading('Actions cache maintenance')
+              .addTable([
+                [
+                  { data: 'Metric', header: true },
+                  { data: 'Value', header: true },
+                ],
+                ['Repository caches inspected', String(caches.length)],
+                ['Caches older than threshold', String(staleCaches.length)],
+                ['Caches deleted', String(deleted)],
+                ['Dry run', String(dryRun)],
+                ['Threshold', `${staleDays} days`],
+              ])
+              .write();

--- a/.github/workflows/delete-cache.workflow.yml
+++ b/.github/workflows/delete-cache.workflow.yml
@@ -1,45 +1,77 @@
-name: 🗑️ Delete old cache
-
-permissions:
-  actions: write
-  contents: read
+name: 🗑️ Cache maintenance
 
 on:
+  schedule:
+    - cron: "17 3 * * 0"
   workflow_dispatch:
     inputs:
-      expired-days:
-        description: "Clear cache that has not been used for x days"
-        default: "7"
+      stale_days:
+        description: Delete caches unused for this many days
         required: true
-  schedule:
-    - cron: "0 0 * * *"
+        default: "7"
+        type: string
+      dry_run:
+        description: Report matching caches without deleting them
+        required: true
+        default: true
+        type: boolean
+
+permissions: read-all
+concurrency:
+  group: cache-maintenance
+  cancel-in-progress: false
 
 jobs:
-  delete-cache:
-    if: github.actor == github.repository_owner || github.actor == 'github-actions'
+  cleanup:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
     steps:
-      - name: 🕐 Calculate ${{ inputs.expired-days || 7 }} days ago
-        id: subtract-days
-        run: echo "date=$(date -u -d '${{ inputs.expired-days || 7 }} days ago' +%Y-%m-%dT%H:%M:%SZ%z)" >> $GITHUB_OUTPUT
-
-      - name: 🧹 Delete old cache
-        id: delete-old-cache
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${GITHUB_REPOSITORY}/actions/caches \
-            -q '.actions_caches[]
-                | { id, last_accessed_at }
-                | select(.last_accessed_at <= "'"${{ steps.subtract-days.outputs.date }}"'")
-                | {id}
-                | .[]' \
-            --paginate | xargs -I {} \
-          gh api \
-            --method DELETE \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${GITHUB_REPOSITORY}/actions/caches/{}
+          STALE_DAYS: ${{ inputs.stale_days || '7' }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
+        with:
+          script: |
+            const staleDays = Number.parseInt(process.env.STALE_DAYS, 10);
+            if (!Number.isInteger(staleDays) || staleDays < 1 || staleDays > 90) {
+              core.setFailed('stale_days must be an integer between 1 and 90');
+              return;
+            }
+            const dryRun = process.env.DRY_RUN === 'true';
+            const cutoff = Date.now() - staleDays * 86400000;
+            const { owner, repo } = context.repo;
+            const caches = await github.paginate(
+              'GET /repos/{owner}/{repo}/actions/caches',
+              { owner, repo, per_page: 100 },
+              (response) => response.data.actions_caches ?? [],
+            );
+            const stale = caches.filter((cache) => {
+              const lastAccessedAt = Date.parse(cache.last_accessed_at);
+              return Number.isFinite(lastAccessedAt) && lastAccessedAt <= cutoff;
+            });
+            let deleted = 0;
+            for (const cache of stale) {
+              core.info(`${dryRun ? 'Would delete' : 'Deleting'} ${cache.id} (${cache.key})`);
+              if (dryRun) continue;
+              try {
+                await github.request(
+                  'DELETE /repos/{owner}/{repo}/actions/caches/{cache_id}',
+                  { owner, repo, cache_id: cache.id },
+                );
+                deleted += 1;
+              } catch (error) {
+                if (error.status === 404) continue;
+                throw error;
+              }
+            }
+            await core.summary.addHeading('Actions cache maintenance').addTable([
+              [{ data: 'Metric', header: true }, { data: 'Value', header: true }],
+              ['Inspected', String(caches.length)],
+              ['Matched', String(stale.length)],
+              ['Deleted', String(deleted)],
+              ['Dry run', String(dryRun)],
+              ['Threshold', `${staleDays} days`],
+            ]).write();

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -1,7 +1,7 @@
 name: 🤖 Pull request automation
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, labeled]
 
 permissions: read-all
@@ -38,11 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
-      issues: read
-      pull-requests: read
+      contents: write
+      issues: write
+      pull-requests: write
     env:
-      AUTOMATION_TOKEN: ${{ secrets.REPOSITORY_AUTOMATION_TOKEN || secrets.PAT_FINE }}
       PR_URL: ${{ github.event.pull_request.html_url }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
@@ -68,20 +67,17 @@ jobs:
           esac
           echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
           echo "manual=$manual" >> "$GITHUB_OUTPUT"
-      - name: Explain missing token
-        if: env.AUTOMATION_TOKEN == ''
-        run: echo "::notice title=Repository automation token missing::Configure REPOSITORY_AUTOMATION_TOKEN or PAT_FINE with Contents, Issues and Pull requests write access."
       - name: Approve and queue eligible update
-        if: env.AUTOMATION_TOKEN != '' && steps.policy.outputs.eligible == 'true'
+        if: steps.policy.outputs.eligible == 'true'
         env:
-          GH_TOKEN: ${{ env.AUTOMATION_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh pr review "$PR_URL" --approve --body "Approved automatically by the repository dependency policy."
           gh pr merge "$PR_URL" --auto --squash --match-head-commit "$HEAD_SHA"
       - name: Mark production major for manual QA
-        if: env.AUTOMATION_TOKEN != '' && steps.policy.outputs.manual == 'true'
+        if: steps.policy.outputs.manual == 'true'
         env:
-          GH_TOKEN: ${{ env.AUTOMATION_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh label create "requires-manual-qa" --color "B60205" --description "Requires explicit maintainer approval before auto-merge" --force
           gh pr edit "$PR_URL" --add-label "requires-manual-qa"

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -1,91 +1,87 @@
-name: 🤖 Dependabot auto-merge
-on: pull_request_target
+name: 🤖 Pull request automation
 
-permissions:
-  contents: write
-  pull-requests: write
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+
+permissions: read-all
+concurrency:
+  group: pull-request-automation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   approve-release:
-    runs-on: ubuntu-latest
-    if: >
+    name: Preserve release approval contract
+    if: >-
       contains(github.event.pull_request.labels.*.name, 'auto-release') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login == github.repository_owner &&
-      (github.actor == github.repository_owner || github.actor == 'github-actions')
-    environment: admin
-    steps:
-      - name: 🔎 Check is approved
-        id: check-is-approved
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const prNumber = context.issue.number;
-            const reviews = await github.rest.pulls.listReviews({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-            const alreadyApproved = reviews.data.some(review => review.state === 'APPROVED');
-            return alreadyApproved;
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: ✅ Approve PR
-        if: steps.check-is-approved.outputs.result == 'false'
-        run: gh pr review $PR_URL --approve -b "I'm **approving** this pull request because **it includes a bump of the version**"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  dependabot:
+      github.event.pull_request.base.ref == github.event.repository.default_branch &&
+      github.event.pull_request.user.login == github.repository_owner
     runs-on: ubuntu-latest
-    if: >
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Approve trusted release PR
+        run: gh pr review "$PR_URL" --approve --body "Approved by the trusted release workflow contract."
+
+  dependabot:
+    name: Validate and queue eligible updates
+    if: >-
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      (github.actor == 'dependabot[bot]' || github.actor == github.repository_owner || github.actor == 'github-actions')
-    environment: admin
+      github.event.pull_request.base.ref == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    env:
+      AUTOMATION_TOKEN: ${{ secrets.REPOSITORY_AUTOMATION_TOKEN || secrets.PAT_FINE }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
-      - name: Fetch actor username
-        id: get_actor_username
-        run: echo "ACTOR_USERNAME=$(gh api user -q .login)" >> $GITHUB_ENV
-        env:
-          GITHUB_TOKEN: ${{secrets.PAT_FINE}}
-      - name: 💿 Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+      - id: metadata
+        name: Read Dependabot metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
-          github-token: "${{secrets.GITHUB_TOKEN}}"
-      - name: ✅ Approve PR if eligible
-        id: approve
+          github-token: ${{ github.token }}
+      - id: policy
+        name: Classify update policy
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
         run: |
-          approved=false
-          if [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-patch" || "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-minor" ]]; then
-            gh pr review "$PR_URL" --approve -b "I'm **approving** this pull request because **it includes a patch or minor update**"
-            approved=true
-          elif [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-major" && "${{ steps.metadata.outputs.dependency-type }}" == "direct:development" ]]; then
-            gh pr review "$PR_URL" --approve -b "I'm **approving** this pull request because **it includes a major update of a dependency used only in development**"
-            approved=true
-          fi
-          echo "approved=$approved" >> $GITHUB_OUTPUT
+          eligible=false
+          manual=false
+          case "$UPDATE_TYPE" in
+            version-update:semver-patch|version-update:semver-minor) eligible=true ;;
+            version-update:semver-major)
+              if [ "$DEPENDENCY_TYPE" = "direct:development" ]; then eligible=true; fi
+              if [ "$DEPENDENCY_TYPE" = "direct:production" ]; then manual=true; fi
+              ;;
+          esac
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+          echo "manual=$manual" >> "$GITHUB_OUTPUT"
+      - name: Explain missing token
+        if: env.AUTOMATION_TOKEN == ''
+        run: echo "::notice title=Repository automation token missing::Configure REPOSITORY_AUTOMATION_TOKEN or PAT_FINE with Contents, Issues and Pull requests write access."
+      - name: Approve and queue eligible update
+        if: env.AUTOMATION_TOKEN != '' && steps.policy.outputs.eligible == 'true'
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.PAT_FINE}}
-      - name: 🔓 Enable auto-merge for eligible PRs
-        if: steps.approve.outputs.approved == 'true'
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v6
-      - name: 👤 Assign PR to user
-        run: gh pr edit $PR_URL --add-assignee "${{ env.ACTOR_USERNAME }}"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.PAT_FINE}}
-      - name: 💬 Comment on major updates of non-development dependencies
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-major' && steps.metadata.outputs.dependency-type == 'direct:production'}}
+          GH_TOKEN: ${{ env.AUTOMATION_TOKEN }}
         run: |
-          gh pr comment $PR_URL --body "I'm **not approving** this PR because **it includes a major update of a dependency used in production**"
-          gh pr edit $PR_URL --add-label "requires-manual-qa"
+          gh pr review "$PR_URL" --approve --body "Approved automatically by the repository dependency policy."
+          gh pr merge "$PR_URL" --auto --squash --match-head-commit "$HEAD_SHA"
+      - name: Mark production major for manual QA
+        if: env.AUTOMATION_TOKEN != '' && steps.policy.outputs.manual == 'true'
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ env.AUTOMATION_TOKEN }}
+        run: |
+          gh label create "requires-manual-qa" --color "B60205" --description "Requires explicit maintainer approval before auto-merge" --force
+          gh pr edit "$PR_URL" --add-label "requires-manual-qa"


### PR DESCRIPTION
## What

- Group weekly npm and GitHub Actions updates behind a seven-day cooldown.
- Replace shell cache deletion with a generic, empty-safe API workflow.
- Remove checkout and mutable Action tags from privileged PR automation.
- Require current write-permission maintainer approval for production majors.
- Preserve the trusted `auto-release` PR approval contract used by the existing package release workflow.

## Security

Dependabot and release-approval jobs use the repository-scoped `GITHUB_TOKEN` on `pull_request` and do not check out PR code. Required-QA approvals are bound to the current PR head SHA.

## Required repository settings

- Enable **Allow auto-merge**.
- Under **Settings → Actions → General → Workflow permissions**, enable **Allow GitHub Actions to create and approve pull requests**.
- Keep required status checks enforced on `main`.

No new secret or repository variable is required by this PR. Existing credentials used by `auto-release.workflow.yml` remain unchanged.

## Scope and validation

`auto-release.workflow.yml` remains unchanged because it owns npm publication semantics. Proposed YAML parsed successfully. No merge, release, npm publication, or deployment was performed.

## Rollback

Revert this PR to restore the previous automation.