### PR TITLE
fix(actions): repair automation actor separation

### DIFF
--- a/.agents/specs/2026-07-29-fix-automation-runtime.md
+++ b/.agents/specs/2026-07-29-fix-automation-runtime.md
@@ -42,6 +42,7 @@ Audit the merged repository automation after real Dependabot executions, correct
 
 - Workflow YAML and repository checks are validated by pull-request CI; changed Actions remain pinned by immutable SHA.
 - `auto-release.workflow.yml` still declares `environment: admin` and reads `secrets.PAT_FINE`; the corrective workflow does not modify that contract.
+- GitHub documents that Dependabot-triggered workflows receive Dependabot secrets and cannot access Actions repository or environment secrets.
 - Full actor-identity validation requires the configured Dependabot secret and subsequent Dependabot/release events after merge.
 
 ## Rollback

--- a/.agents/specs/2026-07-29-fix-automation-runtime.md
+++ b/.agents/specs/2026-07-29-fix-automation-runtime.md
@@ -1,0 +1,43 @@
+# Fix repository automation runtime
+
+## Request
+
+Audit the merged repository automation after real Dependabot executions, correct common failures and preserve the existing release actor contract.
+
+## Evidence
+
+- The shared Dependabot workflow attempted repository-level label creation without an explicit repository and can fail because it intentionally performs no checkout.
+- Eligible Dependabot pull requests were approved by `github-actions[bot]`; the required contract is owner approval followed by GitHub Actions auto-merge.
+- Existing release pull requests are already created with `PAT_FINE` as the repository owner and must continue to be approved by GitHub Actions.
+- `fastypest` uses `requires-manual-qa` color `E99695` and `auto-release` color `FEF2C0`.
+
+## Decision
+
+- Require `PAT_FINE` as a Dependabot repository secret for owner-authored dependency approvals.
+- Preserve the existing Actions `PAT_FINE`, package validation, npm publishing and release workflow without changing its release semantics.
+- Validate secrets inside shell steps rather than referencing secrets directly in `if:` expressions.
+- Let `github.token` approve trusted owner-authored release pull requests and enable dependency auto-merge.
+- Add explicit repository context to label commands, synchronize manual-QA metadata, add fork guards and remove unused cache permissions.
+
+## Acceptance criteria
+
+- Eligible Dependabot updates are approved by `juanjoGonDev` and queued by GitHub Actions.
+- Existing owner-authored release pull requests are approved by `github-actions[bot]` for their exact head SHA.
+- Production majors are labeled correctly and require a current human maintainer approval.
+- Existing package publication behavior remains unchanged.
+- Missing Dependabot credentials fail with explicit setup guidance.
+
+## Validation
+
+- Workflow YAML parsed with a non-coercing loader.
+- Actions remain pinned by immutable SHA in changed workflows.
+- Pull-request CI validates repository checks.
+- Full actor-identity validation requires the configured Dependabot secret and subsequent automation events.
+
+## Rollback
+
+Revert the corrective pull request. The branch does not publish, release or deploy.
+
+## Delivery status
+
+Implementation complete on `agent/fix-automation-runtime`; pull request and CI validation pending.

--- a/.agents/specs/2026-07-29-fix-automation-runtime.md
+++ b/.agents/specs/2026-07-29-fix-automation-runtime.md
@@ -2,42 +2,45 @@
 
 ## Request
 
-Audit the merged repository automation after real Dependabot executions, correct common failures and preserve the existing release actor contract.
+Audit the merged repository automation after real Dependabot executions, correct common failures, create the required labels and preserve the existing release actor contract.
 
 ## Evidence
 
-- The shared Dependabot workflow attempted repository-level label creation without an explicit repository and can fail because it intentionally performs no checkout.
+- Repository-level label creation can fail in no-checkout jobs without explicit repository context.
 - Eligible Dependabot pull requests were approved by `github-actions[bot]`; the required contract is owner approval followed by GitHub Actions auto-merge.
-- Existing release pull requests are already created with `PAT_FINE` as the repository owner and must continue to be approved by GitHub Actions.
-- `fastypest` uses `requires-manual-qa` color `E99695` and `auto-release` color `FEF2C0`.
+- Existing release pull requests are authored with the owner's Actions `PAT_FINE` and must continue to be approved by GitHub Actions for the exact current head.
+- Automated review identified missing approval-actor verification, dry-run label mutation and a concurrent label-creation race.
+- `fastypest` uses `requires-manual-qa` color `E99695` and `auto-release` color `FEF2C0` with its npm release description.
 
 ## Decision
 
-- Require `PAT_FINE` as a Dependabot repository secret for owner-authored dependency approvals.
-- Preserve the existing Actions `PAT_FINE`, package validation, npm publishing and release workflow without changing its release semantics.
-- Validate secrets inside shell steps rather than referencing secrets directly in `if:` expressions.
-- Let `github.token` approve trusted owner-authored release pull requests and enable dependency auto-merge.
-- Add explicit repository context to label commands, synchronize manual-QA metadata, add fork guards and remove unused cache permissions.
+- Require `PAT_FINE` as a Dependabot repository secret with Pull requests read/write.
+- Preserve the existing Actions `PAT_FINE`, package validation, npm publishing and release workflow semantics.
+- Resolve the Dependabot PAT login with `gh api user` and fail unless it equals `GITHUB_REPOSITORY_OWNER` (`juanjoGonDev`).
+- Let `github.token` approve only trusted owner-authored release pull requests for their exact head SHA and enable dependency auto-merge.
+- Surface a precise 403 error when **Allow GitHub Actions to create and approve pull requests** is disabled.
+- Require repository settings **Allow auto-merge** and **Allow GitHub Actions to create and approve pull requests**.
+- Synchronize both automation labels only outside dry-run mode and tolerate only the specific concurrent `422 already_exists` race.
+- Add explicit repository context, fork guards and minimum cache permissions.
 
 ## Acceptance criteria
 
-- Eligible Dependabot updates are approved by `juanjoGonDev` and queued by GitHub Actions.
-- Existing owner-authored release pull requests are approved by `github-actions[bot]` for their exact head SHA.
-- Production majors are labeled correctly and require a current human maintainer approval.
+- Eligible Dependabot updates are approved by `juanjoGonDev`, never by a bot or another PAT owner.
+- Existing owner-authored release PRs are approved by `github-actions[bot]` for the exact current head.
+- Production majors remain manual and require current non-bot write maintainer approval.
+- Manual dry runs make no repository mutation and concurrent label creation cannot abort processing.
 - Existing package publication behavior remains unchanged.
-- Missing Dependabot credentials fail with explicit setup guidance.
+- Missing or incorrectly owned Dependabot credentials fail with precise guidance.
 
 ## Validation
 
-- Workflow YAML parsed with a non-coercing loader.
-- Actions remain pinned by immutable SHA in changed workflows.
-- Pull-request CI validates repository checks.
-- Full actor-identity validation requires the configured Dependabot secret and subsequent automation events.
+- Workflow YAML and repository checks are validated by pull-request CI; changed Actions remain pinned by immutable SHA.
+- Full actor-identity validation requires the configured Dependabot secret and subsequent Dependabot/release events after merge.
 
 ## Rollback
 
-Revert the corrective pull request. The branch does not publish, release or deploy.
+Revert the corrective pull request. The branch does not publish, release, deploy or merge.
 
 ## Delivery status
 
-Implementation complete on `agent/fix-automation-runtime`; pull request and CI validation pending.
+Implemented on `agent/fix-automation-runtime` and delivered through a normal corrective pull request. Existing release semantics are preserved.

--- a/.agents/specs/2026-07-29-fix-automation-runtime.md
+++ b/.agents/specs/2026-07-29-fix-automation-runtime.md
@@ -8,14 +8,18 @@ Audit the merged repository automation after real Dependabot executions, correct
 
 - Repository-level label creation can fail in no-checkout jobs without explicit repository context.
 - Eligible Dependabot pull requests were approved by `github-actions[bot]`; the required contract is owner approval followed by GitHub Actions auto-merge.
-- Existing release pull requests are authored with the owner's Actions `PAT_FINE` and must continue to be approved by GitHub Actions for the exact current head.
+- The release workflow already declares `environment: admin` and reads its Actions environment secret `PAT_FINE` to create owner-authored release branches and pull requests.
+- Workflows initiated by Dependabot cannot read Actions repository or environment secrets; they resolve `secrets.PAT_FINE` only from Dependabot secrets.
+- Existing release pull requests are authored with the owner's `admin` environment `PAT_FINE` and must continue to be approved by GitHub Actions for the exact current head.
 - Automated review identified missing approval-actor verification, dry-run label mutation and a concurrent label-creation race.
 - `fastypest` uses `requires-manual-qa` color `E99695` and `auto-release` color `FEF2C0` with its npm release description.
 
 ## Decision
 
-- Require `PAT_FINE` as a Dependabot repository secret with Pull requests read/write.
-- Preserve the existing Actions `PAT_FINE`, package validation, npm publishing and release workflow semantics.
+- Preserve `PAT_FINE` as an Actions environment secret in `admin` for the existing release workflow.
+- Also require `PAT_FINE` as a Dependabot repository secret with Pull requests read/write because the `admin` environment secret is unavailable to Dependabot-triggered workflows.
+- Do not attach the Dependabot job to `environment: admin`; doing so would not make the Actions environment secret available and could add environment protection gates to dependency automation.
+- Preserve existing package validation, npm publishing and release workflow semantics.
 - Resolve the Dependabot PAT login with `gh api user` and fail unless it equals `GITHUB_REPOSITORY_OWNER` (`juanjoGonDev`).
 - Let `github.token` approve only trusted owner-authored release pull requests for their exact head SHA and enable dependency auto-merge.
 - Surface a precise 403 error when **Allow GitHub Actions to create and approve pull requests** is disabled.
@@ -27,6 +31,8 @@ Audit the merged repository automation after real Dependabot executions, correct
 
 - Eligible Dependabot updates are approved by `juanjoGonDev`, never by a bot or another PAT owner.
 - Existing owner-authored release PRs are approved by `github-actions[bot]` for the exact current head.
+- The release workflow continues to obtain `PAT_FINE` from environment `admin`.
+- Dependabot approval obtains a separately configured Dependabot secret named `PAT_FINE`.
 - Production majors remain manual and require current non-bot write maintainer approval.
 - Manual dry runs make no repository mutation and concurrent label creation cannot abort processing.
 - Existing package publication behavior remains unchanged.
@@ -35,6 +41,7 @@ Audit the merged repository automation after real Dependabot executions, correct
 ## Validation
 
 - Workflow YAML and repository checks are validated by pull-request CI; changed Actions remain pinned by immutable SHA.
+- `auto-release.workflow.yml` still declares `environment: admin` and reads `secrets.PAT_FINE`; the corrective workflow does not modify that contract.
 - Full actor-identity validation requires the configured Dependabot secret and subsequent Dependabot/release events after merge.
 
 ## Rollback

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -30,9 +30,12 @@ jobs:
     steps:
       - name: Synchronize automation labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          DRY_RUN: ${{ inputs.dry_run || false }}
         with:
           github-token: ${{ github.token }}
           script: |
+            const dryRun = process.env.DRY_RUN === 'true';
             const { owner, repo } = context.repo;
             const labels = [
               {
@@ -47,22 +50,42 @@ jobs:
               },
             ];
 
+            const updateLabel = (label) =>
+              github.rest.issues.updateLabel({
+                owner,
+                repo,
+                name: label.name,
+                new_name: label.name,
+                color: label.color,
+                description: label.description,
+              });
+
             for (const label of labels) {
+              if (dryRun) {
+                core.info(`Would synchronize label ${label.name}.`);
+                continue;
+              }
+
               try {
-                await github.rest.issues.updateLabel({
-                  owner,
-                  repo,
-                  name: label.name,
-                  new_name: label.name,
-                  color: label.color,
-                  description: label.description,
-                });
+                await updateLabel(label);
               } catch (error) {
                 if (error.status !== 404) {
                   throw error;
                 }
 
-                await github.rest.issues.createLabel({ owner, repo, ...label });
+                try {
+                  await github.rest.issues.createLabel({ owner, repo, ...label });
+                } catch (createError) {
+                  const duplicate =
+                    createError.status === 422 &&
+                    createError.response?.data?.errors?.some(
+                      (entry) => entry.code === 'already_exists',
+                    );
+                  if (!duplicate) {
+                    throw createError;
+                  }
+                  await updateLabel(label);
+                }
               }
             }
 

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -20,12 +20,43 @@ concurrency:
 jobs:
   process:
     name: Process approved Dependabot majors
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: write
+      issues: write
       pull-requests: write
     steps:
+      - name: Synchronize manual QA label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const label = {
+              name: 'requires-manual-qa',
+              color: 'E99695',
+              description: 'Needs manual quality assurance testing before merging',
+            };
+
+            try {
+              await github.rest.issues.updateLabel({
+                owner,
+                repo,
+                name: label.name,
+                new_name: label.name,
+                color: label.color,
+                description: label.description,
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+
+              await github.rest.issues.createLabel({ owner, repo, ...label });
+            }
+
       - name: Validate current approvals and enable auto-merge
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -28,33 +28,42 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Synchronize manual QA label
+      - name: Synchronize automation labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ github.token }}
           script: |
             const { owner, repo } = context.repo;
-            const label = {
-              name: 'requires-manual-qa',
-              color: 'E99695',
-              description: 'Needs manual quality assurance testing before merging',
-            };
+            const labels = [
+              {
+                name: 'requires-manual-qa',
+                color: 'E99695',
+                description: 'Needs manual quality assurance testing before merging',
+              },
+              {
+                name: 'auto-release',
+                color: 'FEF2C0',
+                description: 'Automatically increases the patch version and publishes to npm',
+              },
+            ];
 
-            try {
-              await github.rest.issues.updateLabel({
-                owner,
-                repo,
-                name: label.name,
-                new_name: label.name,
-                color: label.color,
-                description: label.description,
-              });
-            } catch (error) {
-              if (error.status !== 404) {
-                throw error;
+            for (const label of labels) {
+              try {
+                await github.rest.issues.updateLabel({
+                  owner,
+                  repo,
+                  name: label.name,
+                  new_name: label.name,
+                  color: label.color,
+                  description: label.description,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+
+                await github.rest.issues.createLabel({ owner, repo, ...label });
               }
-
-              await github.rest.issues.createLabel({ owner, repo, ...label });
             }
 
       - name: Validate current approvals and enable auto-merge

--- a/.github/workflows/delete-cache.workflow.yml
+++ b/.github/workflows/delete-cache.workflow.yml
@@ -25,11 +25,11 @@ concurrency:
 jobs:
   cleanup:
     name: 🧹 Delete stale Actions caches
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       actions: write
-      contents: read
     steps:
       - name: Inspect and delete stale caches
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -37,6 +37,7 @@ jobs:
           STALE_DAYS: ${{ inputs.stale_days || '7' }}
           DRY_RUN: ${{ inputs.dry_run || false }}
         with:
+          github-token: ${{ github.token }}
           script: |
             const staleDaysInput = process.env.STALE_DAYS ?? '';
             if (!/^(?:[1-9]|[1-8]\d|90)$/.test(staleDaysInput)) {

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -1,18 +1,24 @@
-name: 🤖 Pull request automation
+name: 🤖 Dependabot auto-merge
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
 
 permissions: read-all
+
 concurrency:
-  group: pull-request-automation-${{ github.event.pull_request.number }}
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   approve-release:
-    name: Preserve release approval contract
+    name: Approve trusted release pull request
     if: >-
+      github.event.repository.fork == false &&
       contains(github.event.pull_request.labels.*.name, 'auto-release') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.base.ref == github.event.repository.default_branch &&
@@ -20,18 +26,45 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
       pull-requests: write
-    env:
-      PR_URL: ${{ github.event.pull_request.html_url }}
-      GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Approve trusted release PR
-        run: gh pr review "$PR_URL" --approve --body "Approved by the trusted release workflow contract."
+      - name: Approve current release head
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pullNumber = context.payload.pull_request.number;
+            const headSha = context.payload.pull_request.head.sha;
+            const reviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              { owner, repo, pull_number: pullNumber, per_page: 100 },
+            );
+            const alreadyApproved = reviews.some(
+              (review) =>
+                review.user?.login === 'github-actions[bot]' &&
+                review.state === 'APPROVED' &&
+                review.commit_id === headSha,
+            );
+
+            if (alreadyApproved) {
+              core.info(`Release PR #${pullNumber} is already approved for ${headSha}.`);
+              return;
+            }
+
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number: pullNumber,
+              commit_id: headSha,
+              event: 'APPROVE',
+              body: 'Approved by the trusted release workflow contract.',
+            });
 
   dependabot:
     name: Validate and queue eligible updates
     if: >-
+      github.event.repository.fork == false &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.base.ref == github.event.repository.default_branch
@@ -45,39 +78,69 @@ jobs:
       PR_URL: ${{ github.event.pull_request.html_url }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
-      - id: metadata
-        name: Read Dependabot metadata
+      - name: Read Dependabot metadata
+        id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ github.token }}
-      - id: policy
-        name: Classify update policy
+
+      - name: Classify update policy
+        id: policy
         env:
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
           DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
         run: |
           eligible=false
-          manual=false
+          requires_manual_qa=false
+
           case "$UPDATE_TYPE" in
-            version-update:semver-patch|version-update:semver-minor) eligible=true ;;
+            version-update:semver-patch|version-update:semver-minor)
+              eligible=true
+              ;;
             version-update:semver-major)
-              if [ "$DEPENDENCY_TYPE" = "direct:development" ]; then eligible=true; fi
-              if [ "$DEPENDENCY_TYPE" = "direct:production" ]; then manual=true; fi
+              if [ "$DEPENDENCY_TYPE" = "direct:development" ]; then
+                eligible=true
+              elif [ "$DEPENDENCY_TYPE" = "direct:production" ]; then
+                requires_manual_qa=true
+              fi
               ;;
           esac
+
           echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
-          echo "manual=$manual" >> "$GITHUB_OUTPUT"
-      - name: Approve and queue eligible update
+          echo "requires_manual_qa=$requires_manual_qa" >> "$GITHUB_OUTPUT"
+
+      - name: Approve eligible update as repository owner
+        if: steps.policy.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error title=Missing Dependabot secret::Configure PAT_FINE as a Dependabot repository secret. It must be a fine-grained token for this repository with Pull requests read/write permission."
+            exit 1
+          fi
+
+          gh pr review "$PR_URL" \
+            --approve \
+            --body "Approved automatically: patch/minor update, or a development-only major update."
+
+      - name: Enable squash auto-merge
         if: steps.policy.outputs.eligible == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr review "$PR_URL" --approve --body "Approved automatically by the repository dependency policy."
-          gh pr merge "$PR_URL" --auto --squash --match-head-commit "$HEAD_SHA"
+          gh pr merge "$PR_URL" \
+            --auto \
+            --squash \
+            --match-head-commit "$HEAD_SHA"
+
       - name: Mark production major for manual QA
-        if: steps.policy.outputs.manual == 'true'
+        if: steps.policy.outputs.requires_manual_qa == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh label create "requires-manual-qa" --color "B60205" --description "Requires explicit maintainer approval before auto-merge" --force
+          gh label create "requires-manual-qa" \
+            --repo "$GITHUB_REPOSITORY" \
+            --color "E99695" \
+            --description "Needs manual quality assurance testing before merging" \
+            --force
           gh pr edit "$PR_URL" --add-label "requires-manual-qa"

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -52,14 +52,24 @@ jobs:
               return;
             }
 
-            await github.rest.pulls.createReview({
-              owner,
-              repo,
-              pull_number: pullNumber,
-              commit_id: headSha,
-              event: 'APPROVE',
-              body: 'Approved by the trusted release workflow contract.',
-            });
+            try {
+              await github.rest.pulls.createReview({
+                owner,
+                repo,
+                pull_number: pullNumber,
+                commit_id: headSha,
+                event: 'APPROVE',
+                body: 'Approved by the trusted release workflow contract.',
+              });
+            } catch (error) {
+              if (error.status === 403) {
+                core.setFailed(
+                  'GitHub Actions cannot approve pull requests. Enable “Allow GitHub Actions to create and approve pull requests” under Settings → Actions → General → Workflow permissions.',
+                );
+                return;
+              }
+              throw error;
+            }
 
   dependabot:
     name: Validate and queue eligible updates
@@ -116,6 +126,12 @@ jobs:
         run: |
           if [ -z "$GH_TOKEN" ]; then
             echo "::error title=Missing Dependabot secret::Configure PAT_FINE as a Dependabot repository secret. It must be a fine-grained token for this repository with Pull requests read/write permission."
+            exit 1
+          fi
+
+          authenticated_login=$(gh api user --jq .login)
+          if [ "$authenticated_login" != "$GITHUB_REPOSITORY_OWNER" ]; then
+            echo "::error title=Invalid Dependabot approval actor::PAT_FINE authenticates as $authenticated_login, but this repository requires $GITHUB_REPOSITORY_OWNER."
             exit 1
           fi
 


### PR DESCRIPTION
## What

- Repair no-checkout label operations and cache permissions.
- Approve eligible Dependabot PRs only through an owner-authenticated Dependabot `PAT_FINE`.
- Preserve the existing owner-authored release PR contract and exact-head approval by `github-actions[bot]`.
- Synchronize `requires-manual-qa` and `auto-release` to the `fastypest` metadata.
- Make label synchronization dry-run safe and resilient to concurrent duplicate creation.
- Preserve existing package validation, npm publication and release semantics.

## Actor contract

- Dependabot authors dependency PRs; its Dependabot secret `PAT_FINE` must resolve through `gh api user` exactly to `juanjoGonDev`; GitHub Actions queues expected-head squash auto-merge.
- The existing release workflow keeps `environment: admin` and obtains its Actions environment secret `PAT_FINE` there to author release branches and PRs as `juanjoGonDev`.
- GitHub Actions approves the exact current head of trusted owner-authored release PRs.
- Production dependency majors remain manual and require a current non-bot write-maintainer approval.

## Secret scopes

The two `PAT_FINE` entries have the same name but different GitHub secret scopes:

1. **Actions environment secret — environment `admin`**
   - Existing configuration; keep it unchanged.
   - Used only by `auto-release.workflow.yml`.
   - Requires the existing release permissions.
2. **Dependabot repository secret**
   - Required by `dependabot-auto-merge.workflow.yml` because Dependabot-triggered workflows cannot access Actions repository or environment secrets.
   - Restrict it to this repository with **Pull requests: Read and write**.

Adding `environment: admin` to the Dependabot job would not expose the Actions environment secret and could add environment approval gates, so the corrective workflow intentionally does not do that.

## Labels

Both label names exist. The first non-dry-run QA workflow execution after merge normalizes them:

- `requires-manual-qa`: `E99695` — `Needs manual quality assurance testing before merging`
- `auto-release`: `FEF2C0` — `Automatically increases the patch version and publishes to npm`

## Required repository settings

Keep these enabled:

- **Allow auto-merge**
- **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests**

The second setting is required because GitHub Actions approves trusted release PRs created with the owner token.

## Validation

Final head: `43af3b773984c716fb6916ef242e514a3dab51b3`.

- Confirmed `auto-release.workflow.yml` declares `environment: admin` and reads `secrets.PAT_FINE`.
- Confirmed the corrective Dependabot workflow reads `secrets.PAT_FINE` without changing the release workflow.
- GitHub documentation confirms that Dependabot-triggered workflows receive Dependabot secrets and cannot access Actions environment secrets.
- Existing package validation, npm publication and release behavior remain unchanged.
- No npm publication, release, deployment or merge was performed.

## Activation after merge

Existing Dependabot PRs require a new `synchronize` or `reopened` event after merge and creation of the Dependabot repository secret.

## Rollback

Revert this PR to restore the previous automation.