### PR TITLE
fix(actions): require manual review for major updates

### DIFF
--- a/.agents/specs/2026-07-29-dependabot-major-policy.md
+++ b/.agents/specs/2026-07-29-dependabot-major-policy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-In progress.
+Ready for review.
 
 ## Request
 
@@ -10,7 +10,7 @@ Prevent every semantic-version major Dependabot update from being approved or qu
 
 ## Evidence
 
-The current workflow marks development-only major updates as eligible. Toolchain and runtime majors can require migrations even when classified as development dependencies.
+The previous workflow marked development-only major updates as eligible. Toolchain and runtime majors can require migrations even when classified as development dependencies.
 
 ## Decision
 
@@ -27,11 +27,14 @@ Classify only patch and minor updates as eligible. Classify every major update a
 
 ## Validation
 
-Pending workflow syntax review, pull-request checks and runtime evidence from the next Dependabot event.
+- CI run `30471389469`: success.
+- The Dependabot job is skipped as expected because this corrective PR is owner-authored.
+- The `admin` environment release secret and trusted release-PR approval flow are unchanged.
 
 ## Delivery
 
 Branch: `agent/fix-dependabot-major-policy`.
+Pull request: `#240`.
 
 ## Rollback
 

--- a/.agents/specs/2026-07-29-dependabot-major-policy.md
+++ b/.agents/specs/2026-07-29-dependabot-major-policy.md
@@ -1,0 +1,38 @@
+# Dependabot major update policy
+
+## Status
+
+In progress.
+
+## Request
+
+Prevent every semantic-version major Dependabot update from being approved or queued automatically. Patch and minor updates may retain the existing owner-approval and expected-head auto-merge flow.
+
+## Evidence
+
+The current workflow marks development-only major updates as eligible. Toolchain and runtime majors can require migrations even when classified as development dependencies.
+
+## Decision
+
+Classify only patch and minor updates as eligible. Classify every major update as requiring manual QA, independent of dependency type. Keep the existing actor separation: the owner PAT approves eligible updates and `github-actions[bot]` queues expected-head squash auto-merge. Preserve the separate trusted release-PR approval contract.
+
+## Acceptance criteria
+
+- Patch and minor updates remain eligible.
+- Every major update receives `requires-manual-qa` and is not auto-approved or queued.
+- Unknown update types are ignored safely.
+- The classification step exercises patch, minor, major and unknown contract cases before processing the event.
+- Workflow permissions remain least-privilege.
+- Release PR behavior remains unchanged.
+
+## Validation
+
+Pending workflow syntax review, pull-request checks and runtime evidence from the next Dependabot event.
+
+## Delivery
+
+Branch: `agent/fix-dependabot-major-policy`.
+
+## Rollback
+
+Revert the workflow and this specification.

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -98,21 +98,48 @@ jobs:
         id: policy
         env:
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
-          DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
         run: |
+          set -euo pipefail
+
+          classify_update() {
+            case "$1" in
+              version-update:semver-patch|version-update:semver-minor)
+                printf '%s\n' eligible
+                ;;
+              version-update:semver-major)
+                printf '%s\n' manual
+                ;;
+              *)
+                printf '%s\n' ignored
+                ;;
+            esac
+          }
+
+          assert_decision() {
+            input=$1
+            expected=$2
+            actual=$(classify_update "$input")
+            if [ "$actual" != "$expected" ]; then
+              echo "::error title=Dependabot policy contract failed::$input resolved to $actual instead of $expected."
+              exit 1
+            fi
+          }
+
+          assert_decision version-update:semver-patch eligible
+          assert_decision version-update:semver-minor eligible
+          assert_decision version-update:semver-major manual
+          assert_decision unknown ignored
+
           eligible=false
           requires_manual_qa=false
+          decision=$(classify_update "$UPDATE_TYPE")
 
-          case "$UPDATE_TYPE" in
-            version-update:semver-patch|version-update:semver-minor)
+          case "$decision" in
+            eligible)
               eligible=true
               ;;
-            version-update:semver-major)
-              if [ "$DEPENDENCY_TYPE" = "direct:development" ]; then
-                eligible=true
-              elif [ "$DEPENDENCY_TYPE" = "direct:production" ]; then
-                requires_manual_qa=true
-              fi
+            manual)
+              requires_manual_qa=true
               ;;
           esac
 
@@ -137,7 +164,7 @@ jobs:
 
           gh pr review "$PR_URL" \
             --approve \
-            --body "Approved automatically: patch/minor update, or a development-only major update."
+            --body "Approved automatically: patch or minor update."
 
       - name: Enable squash auto-merge
         if: steps.policy.outputs.eligible == 'true'
@@ -149,7 +176,7 @@ jobs:
             --squash \
             --match-head-commit "$HEAD_SHA"
 
-      - name: Mark production major for manual QA
+      - name: Mark major update for manual QA
         if: steps.policy.outputs.requires_manual_qa == 'true'
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What

- Stop auto-approving every semantic-version major Dependabot update.
- Keep patch and minor updates on the existing owner-PAT approval and expected-head squash auto-merge path.
- Mark every major with `requires-manual-qa`.
- Exercise patch, minor, major and unknown policy cases inside the classification step before applying the event decision.
- Preserve the trusted release-PR approval contract unchanged.

## Why

Dependency type is not a reliable risk boundary. Compiler, lint, runtime and Actions majors can require migrations or break CI even when classified as development dependencies.

## Security and actors

- Dependabot remains the dependency PR author.
- The repository-owner Dependabot `PAT_FINE` approves only patch/minor updates.
- `github-actions[bot]` only queues expected-head auto-merge for those eligible updates.
- Major updates receive no automated approval or merge request.
- Owner-authored `auto-release` PR behavior and the `admin` environment release secret remain unchanged.

## Validation

- Branch is exactly two commits ahead of `main` and changes only the task spec and Dependabot workflow.
- The classification contract asserts patch → eligible, minor → eligible, major → manual and unknown → ignored.
- Pull-request checks are pending on this head.

## Risk

Low. The change is intentionally more restrictive.

## Rollback

Revert this pull request.