### PR TITLE
Bump version to v1.0.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.58](https://github.com/juanjoGonDev/typeorm-test-db/compare/v1.0.57...v1.0.58) (2026-08-01)
+
+
+### Bug Fixes
+
+* **actions:** repair automation actor separation ([#239](https://github.com/juanjoGonDev/typeorm-test-db/issues/239)) ([f60053d](https://github.com/juanjoGonDev/typeorm-test-db/commit/f60053d5ba79622e32ea7e83fea433b2ff57dd9f))
+* **actions:** require manual review for major updates ([#240](https://github.com/juanjoGonDev/typeorm-test-db/issues/240)) ([6411a04](https://github.com/juanjoGonDev/typeorm-test-db/commit/6411a04b236405c8d5a4c7a935ed9d48d5d93924))
+* **release:** delegate delivery to repository auto-merge ([#243](https://github.com/juanjoGonDev/typeorm-test-db/issues/243)) ([c95d8df](https://github.com/juanjoGonDev/typeorm-test-db/commit/c95d8df21f47ae3b77e281547d947a8c93672315))
+
 ### [1.0.57](https://github.com/juanjoGonDev/typeorm-test-db/compare/v1.0.56...v1.0.57) (2026-07-23)
 
 ### [1.0.56](https://github.com/juanjoGonDev/typeorm-test-db/compare/v1.0.55...v1.0.56) (2026-07-10)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm-test-db",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Automated transactional lifecycle helpers for TypeORM tests",
   "license": "GPL-3.0-only",
   "main": "dist/index.js",


### PR DESCRIPTION
Bumps version to v1.0.58. Publication starts only after this pull request is merged by the repository requirements.