### PR TITLE
refactor(release): split event-driven delivery

### DIFF
--- a/.agents/specs/2026-08-01-event-driven-release-pipeline.md
+++ b/.agents/specs/2026-08-01-event-driven-release-pipeline.md
@@ -1,0 +1,152 @@
+# Event-driven release pipeline
+
+## Request
+
+Apply the release separation proven in `fastypest` to `typeorm-test-db`:
+
+1. Evaluate the commit threshold after each default-branch push and prepare an owner-authored version pull request.
+2. Validate the generated release pull request and enable repository-controlled squash auto-merge only for its exact trusted head.
+3. Create an immutable GitHub Release after the package version changes on the default branch.
+4. Publish to npm from the GitHub `release.published` event so manual and automated GitHub Releases use the same trusted-publisher path.
+5. Preserve `.github/workflows/auto-release.workflow.yml` as the npm trusted-publisher workflow identity.
+
+No merge, GitHub Release, tag, npm publication, or deployment is part of this implementation delivery.
+
+## Evidence
+
+- The current preparation workflow is schedule-driven and creates `release/<run-number>` branches.
+- The current npm workflow is coupled to release pull-request closure.
+- `package.json` is `typeorm-test-db@1.0.57`.
+- Pull request `#244` is an existing release pull request created by the previous pipeline and remains outside this implementation branch.
+- The repository supports native auto-merge.
+- The `admin` environment already owns the release automation credential and npm OIDC boundary.
+
+## Scope
+
+### In scope
+
+- `.github/workflows/prepare-release.workflow.yml`
+- `.github/workflows/release-auto-merge.workflow.yml`
+- `.github/workflows/create-github-release.workflow.yml`
+- `.github/workflows/auto-release.workflow.yml`
+- `.github/workflows/dependabot-auto-merge.workflow.yml`
+- this task specification
+
+### Out of scope
+
+- merging implementation or release pull requests
+- modifying package source or package version
+- publishing npm packages
+- creating or changing repository secrets, environments, branch rules, tags, or releases
+- applying the change to any other repository
+
+## Decision
+
+### Preparation
+
+`prepare-release.workflow.yml` runs for every push to the default branch and through an explicit manual dispatch. It:
+
+- binds work to the exact event commit
+- requires the current `package.json` version to have a matching published GitHub Release
+- rejects release drift, missing tags, wrong tag targets, or non-ancestor baselines
+- leaves an existing trusted release pull request untouched
+- counts commits from the current release tag
+- preserves the four-commit threshold and explicit force/dry-run controls
+- builds and package-smoke-tests before versioning
+- creates `release/v<version>` without pushing the local `standard-version` tag
+- creates an owner-authored, labeled pull request but does not merge or publish
+
+### Release pull-request trust
+
+`release-auto-merge.workflow.yml` is the sole owner of release pull-request validation and approval. It runs from the trusted default-branch workflow definition and never checks out or executes pull-request code. It validates:
+
+- same repository, owner author, default base, `auto-release` label, and exact `release/v<version>` branch
+- current event and live head SHA equality
+- exact title contract
+- strict and monotonic SemVer
+- package identity and version
+- exact changed files: `CHANGELOG.md` and `package.json`
+- changelog release entry
+- absence of a destination tag or GitHub Release
+- approval bound to the exact validated head
+
+The owner-scoped `PAT_FINE` enables native squash auto-merge with `--match-head-commit`, allowing repository requirements to remain the merge authority and ensuring the resulting push can trigger downstream workflows.
+
+### GitHub Release
+
+`create-github-release.workflow.yml` runs after each default-branch push and supports owner recovery through an exact version input. It:
+
+- no-ops when `package.json` did not change
+- resolves the first-parent commit that introduced the current version, including multi-commit pushes and later same-version metadata changes
+- rejects non-SemVer versions, ancestry violations, tag collisions, release target collisions, and metadata drift
+- validates the `PAT_FINE` actor as the repository owner
+- creates an immutable lightweight tag and generated GitHub Release notes
+- verifies tag target and release metadata
+- emits a user-authored `release.published` event for the npm workflow
+
+### npm publication
+
+`.github/workflows/auto-release.workflow.yml` retains its filename and `name: 🔄 Auto release`. It now runs only for `release.published` and:
+
+- accepts only non-draft owner-authored releases in the source repository
+- validates package name, tag/version equality, strict SemVer, prerelease metadata, and default-branch ancestry
+- performs frozen installation, build, archive inspection, and consumer installation smoke testing
+- checks npm state idempotently
+- publishes through npm OIDC only, using `latest` for stable versions and `next` for prereleases
+- verifies package visibility and the destination dist-tag
+- has no long-lived npm token fallback
+
+### Dependabot
+
+`dependabot-auto-merge.workflow.yml` returns to one responsibility: Dependabot policy. Patch and minor updates remain eligible; majors remain manual. Release validation is not duplicated there.
+
+## Risks and controls
+
+- **Privileged event handling:** release validation uses a trusted workflow definition and never executes PR content.
+- **Secret exposure:** release jobs are restricted to the `admin` environment and validate the authenticated token owner.
+- **Stale events:** every approval and merge action rechecks the current head SHA.
+- **Event suppression:** event-emitting transitions use the owner token rather than `GITHUB_TOKEN`.
+- **Tag replacement:** no force push or tag mutation is permitted.
+- **Duplicate publication:** GitHub Release and npm operations are idempotent and fail closed on mismatched existing state.
+- **Manual releases:** they must use an owner-authored GitHub Release whose tag points to a default-branch package version.
+- **Existing PR #244:** it was created under the previous branch contract. This implementation does not mutate or merge it.
+
+## Acceptance criteria
+
+- A default-branch push evaluates the release threshold.
+- Below threshold, preparation exits successfully without a branch or PR.
+- At or above threshold, preparation creates only a version/changelog PR.
+- The generated PR cannot be approved or queued unless all trust checks pass for the exact current head.
+- Merging a version PR causes GitHub Release creation from the exact version-introducing commit.
+- Publishing a valid owner GitHub Release invokes the unchanged npm trusted-publisher workflow file.
+- Manual and automated GitHub Releases share the same npm path.
+- No workflow polls check runs or directly decides which required tests constitute merge eligibility.
+- No npm token fallback, force tag update, destructive cleanup, or PR-code execution in privileged jobs exists.
+
+## Checks
+
+- Parse all changed workflow YAML.
+- Run `bash -n` over every changed shell block after neutralizing GitHub expressions.
+- Run JavaScript syntax checks over `actions/github-script` programs.
+- Verify every third-party Action reference is pinned to a full commit SHA.
+- Assert the npm workflow filename and display name remain unchanged.
+- Assert preparation contains no npm publication, tag push, release creation, direct merge, or check polling.
+- Assert GitHub Release creation contains no npm publication.
+- Assert npm publication is triggered only by `release.published`.
+- Assert no force push, tag mutation, npm token fallback, or destructive failure cleanup exists.
+- Run repository CI on the final pull-request head.
+
+## Rollback
+
+Revert the implementation pull request. Existing tags, GitHub Releases, npm versions, and the open release pull request remain immutable external evidence and are not deleted.
+
+## Delivery
+
+- Branch: `agent/refactor-event-driven-release`
+- Pull request: pending
+- Merge: requires explicit owner approval
+- Publication: not performed
+
+## Status
+
+Implementation in progress.

--- a/.agents/specs/2026-08-01-event-driven-release-pipeline.md
+++ b/.agents/specs/2026-08-01-event-driven-release-pipeline.md
@@ -14,12 +14,14 @@ No merge, GitHub Release, tag, npm publication, or deployment is part of this im
 
 ## Evidence
 
-- The current preparation workflow is schedule-driven and creates `release/<run-number>` branches.
-- The current npm workflow is coupled to release pull-request closure.
-- `package.json` is `typeorm-test-db@1.0.57`.
+- The previous preparation workflow was schedule-driven and created `release/<run-number>` branches.
+- The previous npm workflow was coupled to release pull-request closure.
+- `package.json` remains `typeorm-test-db@1.0.57` in this implementation branch.
 - Pull request `#244` is an existing release pull request created by the previous pipeline and remains outside this implementation branch.
 - The repository supports native auto-merge.
 - The `admin` environment already owns the release automation credential and npm OIDC boundary.
+- Review findings from the equivalent DevBar workflow exposed three shared safety defects: approval creation not atomically bound to the validated head, monotonicity checked against a recorded PR base SHA instead of the live default branch, and release metadata checked only after attempting to fetch a potentially absent draft tag.
+- Pull request `#245` received no CodeRabbit inline findings; the shared defects were proactively corrected here to keep both release implementations aligned.
 
 ## Scope
 
@@ -63,7 +65,7 @@ No merge, GitHub Release, tag, npm publication, or deployment is part of this im
 - same repository, owner author, default base, `auto-release` label, and exact `release/v<version>` branch
 - current event and live head SHA equality
 - exact title contract
-- strict and monotonic SemVer
+- strict and monotonic SemVer against the live default-branch package version
 - package identity and version
 - exact changed files: `CHANGELOG.md` and `package.json`
 - changelog release entry
@@ -79,6 +81,7 @@ The owner-scoped `PAT_FINE` enables native squash auto-merge with `--match-head-
 - no-ops when `package.json` did not change
 - resolves the first-parent commit that introduced the current version, including multi-commit pushes and later same-version metadata changes
 - rejects non-SemVer versions, ancestry violations, tag collisions, release target collisions, and metadata drift
+- validates draft/prerelease metadata before attempting to fetch an existing tag
 - validates the `PAT_FINE` actor as the repository owner
 - creates an immutable lightweight tag and generated GitHub Release notes
 - verifies tag target and release metadata
@@ -98,14 +101,16 @@ The owner-scoped `PAT_FINE` enables native squash auto-merge with `--match-head-
 
 ### Dependabot
 
-`dependabot-auto-merge.workflow.yml` returns to one responsibility: Dependabot policy. Patch and minor updates remain eligible; majors remain manual. Release validation is not duplicated there.
+`dependabot-auto-merge.workflow.yml` returns to one responsibility: Dependabot policy. Patch and minor updates remain eligible; majors remain manual. Release validation is not duplicated there. Owner approval is created through the pull-request review API with an explicit `commit_id`, after confirming the live head still equals the event head.
 
 ## Risks and controls
 
 - **Privileged event handling:** release validation uses a trusted workflow definition and never executes PR content.
 - **Secret exposure:** release jobs are restricted to the `admin` environment and validate the authenticated token owner.
-- **Stale events:** every approval and merge action rechecks the current head SHA.
+- **Stale events:** every approval and merge action rechecks the current head SHA; Dependabot approvals are attached to the exact validated commit.
+- **Stale version baseline:** release PR monotonicity is checked against the live default branch rather than the PR's recorded base SHA.
 - **Event suppression:** event-emitting transitions use the owner token rather than `GITHUB_TOKEN`.
+- **Draft release diagnostics:** release metadata is rejected before any tag fetch that could otherwise fail opaquely.
 - **Tag replacement:** no force push or tag mutation is permitted.
 - **Duplicate publication:** GitHub Release and npm operations are idempotent and fail closed on mismatched existing state.
 - **Manual releases:** they must use an owner-authored GitHub Release whose tag points to a default-branch package version.
@@ -117,6 +122,9 @@ The owner-scoped `PAT_FINE` enables native squash auto-merge with `--match-head-
 - Below threshold, preparation exits successfully without a branch or PR.
 - At or above threshold, preparation creates only a version/changelog PR.
 - The generated PR cannot be approved or queued unless all trust checks pass for the exact current head.
+- Dependabot approval cannot migrate to a newer unvalidated head.
+- A release PR cannot pass monotonicity using a stale default-branch version.
+- Draft or prerelease metadata fails with the intended release diagnostic before tag retrieval.
 - Merging a version PR causes GitHub Release creation from the exact version-introducing commit.
 - Publishing a valid owner GitHub Release invokes the unchanged npm trusted-publisher workflow file.
 - Manual and automated GitHub Releases share the same npm path.
@@ -125,16 +133,17 @@ The owner-scoped `PAT_FINE` enables native squash auto-merge with `--match-head-
 
 ## Checks
 
-- Parse all changed workflow YAML.
-- Run `bash -n` over every changed shell block after neutralizing GitHub expressions.
-- Run JavaScript syntax checks over `actions/github-script` programs.
-- Verify every third-party Action reference is pinned to a full commit SHA.
-- Assert the npm workflow filename and display name remain unchanged.
-- Assert preparation contains no npm publication, tag push, release creation, direct merge, or check polling.
-- Assert GitHub Release creation contains no npm publication.
-- Assert npm publication is triggered only by `release.published`.
-- Assert no force push, tag mutation, npm token fallback, or destructive failure cleanup exists.
-- Run repository CI on the final pull-request head.
+- Workflow YAML parsed by GitHub Actions.
+- Shell blocks and `actions/github-script` programs passed the implementation static validation.
+- Every third-party Action reference remains pinned to a full commit SHA.
+- The npm workflow filename and display name remain unchanged.
+- Preparation contains no npm publication, tag push, release creation, direct merge, or check polling.
+- GitHub Release creation contains no npm publication.
+- npm publication is triggered only by `release.published`.
+- No force push, tag mutation, npm token fallback, or destructive failure cleanup exists.
+- CI run `30715397205`: success.
+- Dependabot-only run `30715397204`: skipped as expected for an owner-authored implementation PR.
+- CodeRabbit: no inline review threads or findings were present on pull request `#245`; the three shared safety defects identified in DevBar were proactively corrected here.
 
 ## Rollback
 
@@ -143,10 +152,10 @@ Revert the implementation pull request. Existing tags, GitHub Releases, npm vers
 ## Delivery
 
 - Branch: `agent/refactor-event-driven-release`
-- Pull request: pending
+- Pull request: `#245`
 - Merge: requires explicit owner approval
 - Publication: not performed
 
 ## Status
 
-Implementation in progress.
+Implementation, cross-repository review hardening, and repository validation are complete. Delivery remains gated by explicit owner merge approval; no merge, tag, GitHub Release, npm publication, or deployment has been performed.

--- a/.github/workflows/auto-release.workflow.yml
+++ b/.github/workflows/auto-release.workflow.yml
@@ -1,255 +1,90 @@
 name: 🔄 Auto release
 
 on:
-  pull_request:
+  release:
     types:
-      - closed
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: "Validate the current version without publishing"
-        required: false
-        default: "false"
-        type: choice
-        options:
-          - "true"
-          - "false"
+      - published
 
 permissions: read-all
 
 concurrency:
-  group: auto-release-${{ github.repository }}-${{ github.event.pull_request.number || github.run_id }}
+  group: npm-publish-${{ github.repository }}-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
 env:
   NODE_VERSION: ${{ vars.NODE_VERSION }}
   PNPM_VERSION: ${{ vars.PNPM_VERSION }}
-
-run-name: 🔄 Auto release${{ github.event.inputs.dry_run == 'true' && ' (dry)' || '' }}
+  EXPECTED_PACKAGE_NAME: typeorm-test-db
 
 jobs:
-  publish-current-version:
-    if: github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner
-    name: 🚑 Publish current version${{ github.event.inputs.dry_run == 'true' && ' (dry)' || '' }}
+  publish:
+    name: Publish trusted GitHub Release to npm
+    if: >-
+      github.event.repository.fork == false &&
+      github.event.release.draft == false &&
+      github.event.release.author.login == github.repository_owner
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: admin
     permissions:
-      contents: write
+      contents: read
       id-token: write
     steps:
-      - name: 📥 Checkout main
+      - name: 📥 Checkout published release tag
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
-          token: ${{ secrets.PAT_FINE }}
+          persist-credentials: false
 
-      - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-        with:
-          version: "${{ env.PNPM_VERSION }}"
-          run_install: false
-
-      - name: 🟢 Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          node-version: "20"
-          cache: pnpm
-          registry-url: "https://registry.npmjs.org"
-
-      - name: 🔄 Update npm
-        run: npm install --global npm@11.5.1
-
-      - name: ⚙️ Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: 🚧 Run build
-        run: pnpm build
-
-      - name: 🧪 Install package test
-        run: |
-          set -euo pipefail
-          test_dir=$(mktemp -d)
-          pnpm pack --pack-destination "$test_dir"
-          cd "$test_dir"
-          echo '{"name":"test-package","version":"1.0.0","private":true}' > package.json
-          package_tarball=$(find . -maxdepth 1 -name '*.tgz' -print -quit)
-          pnpm add --save-dev "$package_tarball"
-
-      - name: 🏷️ Resolve current version
-        id: metadata
+      - name: 🔐 Validate published release contract
+        id: release
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          EVENT_PRERELEASE: ${{ github.event.release.prerelease }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           package_name=$(node -p "require('./package.json').name")
           package_version=$(node -p "require('./package.json').version")
-          echo "package_name=$package_name" >> "$GITHUB_OUTPUT"
-          echo "package_version=$package_version" >> "$GITHUB_OUTPUT"
-          echo "release_tag=v${package_version}" >> "$GITHUB_OUTPUT"
-          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          expected_tag="v${package_version}"
 
-      - name: 🚫 Dry run active
-        if: github.event.inputs.dry_run == 'true'
-        run: echo "Current version recovery validated without publishing."
-
-      - name: 🔒 Validate recovery tag state
-        if: github.event.inputs.dry_run != 'true'
-        id: tag_state
-        env:
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-          COMMIT_SHA: ${{ steps.metadata.outputs.commit_sha }}
-        run: |
-          set -euo pipefail
-          git fetch --tags --force
-          if git rev-parse --verify "${RELEASE_TAG}^{commit}" >/dev/null 2>&1; then
-            existing_sha=$(git rev-list -n 1 "$RELEASE_TAG")
-            if [[ "$existing_sha" != "$COMMIT_SHA" ]]; then
-              echo "::error title=Release tag collision::$RELEASE_TAG points to $existing_sha instead of $COMMIT_SHA."
-              exit 1
-            fi
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [[ "$package_name" != "$EXPECTED_PACKAGE_NAME" ]]; then
+            echo "::error title=Unexpected package::Expected $EXPECTED_PACKAGE_NAME, received $package_name."
+            exit 1
           fi
-          echo "exists=false" >> "$GITHUB_OUTPUT"
-
-      - name: 🔎 Check npm publication state
-        if: github.event.inputs.dry_run != 'true'
-        id: npm_state
-        env:
-          PACKAGE_NAME: ${{ steps.metadata.outputs.package_name }}
-          PACKAGE_VERSION: ${{ steps.metadata.outputs.package_version }}
-        run: |
-          set -euo pipefail
-          error_file=$(mktemp)
-          set +e
-          published_json=$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --json 2>"$error_file")
-          status=$?
-          set -e
-
-          if (( status == 0 )); then
-            published_version=$(jq -r . <<<"$published_json")
-            [[ "$published_version" == "$PACKAGE_VERSION" ]]
-            echo "published=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [[ "$RELEASE_TAG" != "$expected_tag" ]]; then
+            echo "::error title=Release version mismatch::Release tag $RELEASE_TAG does not match package.json version $package_version."
+            exit 1
           fi
-
-          if grep -Eq 'E404|404 Not Found' "$error_file"; then
-            echo "published=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          cat "$error_file"
-          exit "$status"
-
-      - name: 🎉 Publish to npm
-        if: github.event.inputs.dry_run != 'true' && steps.npm_state.outputs.published != 'true'
-        run: npm publish
-
-      - name: 🏷️ Create immutable release tag
-        if: github.event.inputs.dry_run != 'true' && steps.tag_state.outputs.exists != 'true'
-        env:
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-          COMMIT_SHA: ${{ steps.metadata.outputs.commit_sha }}
-        run: |
-          set -euo pipefail
-          git tag "$RELEASE_TAG" "$COMMIT_SHA"
-          git push origin "refs/tags/${RELEASE_TAG}"
-
-      - name: 📦 Create GitHub Release
-        if: github.event.inputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-        run: |
-          set -euo pipefail
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            exit 0
-          fi
-          gh release create "$RELEASE_TAG" \
-            --verify-tag \
-            --title "Release ${RELEASE_TAG}" \
-            --notes "Automated recovery release ${RELEASE_TAG}."
-
-      - name: ✅ Verify recovered release
-        if: github.event.inputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PACKAGE_NAME: ${{ steps.metadata.outputs.package_name }}
-          PACKAGE_VERSION: ${{ steps.metadata.outputs.package_version }}
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-          COMMIT_SHA: ${{ steps.metadata.outputs.commit_sha }}
-        run: |
-          set -euo pipefail
-          published_version=$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --json | jq -r .)
-          [[ "$published_version" == "$PACKAGE_VERSION" ]]
-          gh release view "$RELEASE_TAG" >/dev/null
-          tag_sha=$(git rev-list -n 1 "$RELEASE_TAG")
-          [[ "$tag_sha" == "$COMMIT_SHA" ]]
-
-  publish:
-    if: >-
-      github.event.repository.fork == false &&
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'auto-release') &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.base.ref == github.event.repository.default_branch &&
-      github.event.pull_request.user.login == github.repository_owner &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
-    name: Publish trusted merged release
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    environment: admin
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: read
-    steps:
-      - name: 🔐 Validate merged release contract
-        id: contract
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: |
-          set -euo pipefail
-          pull_json=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
-          merged=$(jq -r .merged <<<"$pull_json")
-          head_sha=$(jq -r .head.sha <<<"$pull_json")
-          merge_sha=$(jq -r .merge_commit_sha <<<"$pull_json")
-          head_repo=$(jq -r .head.repo.full_name <<<"$pull_json")
-          head_ref=$(jq -r .head.ref <<<"$pull_json")
-          base_ref=$(jq -r .base.ref <<<"$pull_json")
-          author=$(jq -r .user.login <<<"$pull_json")
-          auto_release_label=$(jq -r '[.labels[].name] | index("auto-release") != null' <<<"$pull_json")
-
-          [[ "$merged" == "true" ]]
-          [[ "$head_sha" == "$EVENT_HEAD_SHA" ]]
-          [[ "$merge_sha" == "$EVENT_MERGE_SHA" ]]
-          [[ "$head_repo" == "$GITHUB_REPOSITORY" ]]
-          [[ "$head_ref" == release/* ]]
-          [[ "$base_ref" == "$DEFAULT_BRANCH" ]]
-          [[ "$author" == "$GITHUB_REPOSITORY_OWNER" ]]
-          [[ "$auto_release_label" == "true" ]]
-
-          mapfile -t changed_files < <(
-            gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename' | sort
-          )
-          expected_files=("CHANGELOG.md" "package.json")
-          if [[ "${changed_files[*]}" != "${expected_files[*]}" ]]; then
-            echo "::error title=Unexpected release files::Expected CHANGELOG.md and package.json, received: ${changed_files[*]}"
+          if ! [[ "$package_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error title=Invalid package version::$package_version is not a supported semantic version."
             exit 1
           fi
 
-          echo "merge_sha=$merge_sha" >> "$GITHUB_OUTPUT"
+          expected_prerelease=false
+          npm_tag=latest
+          if [[ "$package_version" == *-* ]]; then
+            expected_prerelease=true
+            npm_tag=next
+          fi
+          if [[ "$EVENT_PRERELEASE" != "$expected_prerelease" ]]; then
+            echo "::error title=Prerelease mismatch::GitHub Release prerelease=$EVENT_PRERELEASE but package version is $package_version."
+            exit 1
+          fi
 
-      - name: 📥 Checkout merged commit
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          ref: ${{ steps.contract.outputs.merge_sha }}
-          fetch-depth: 0
-          token: ${{ secrets.PAT_FINE }}
+          git fetch --force origin "$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH" \
+            "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          release_sha=$(git rev-list -n 1 "$RELEASE_TAG")
+          if ! git merge-base --is-ancestor "$release_sha" "refs/remotes/origin/$DEFAULT_BRANCH"; then
+            echo "::error title=Untrusted release commit::$RELEASE_TAG is not reachable from $DEFAULT_BRANCH."
+            exit 1
+          fi
+
+          echo "package_name=$package_name" >> "$GITHUB_OUTPUT"
+          echo "package_version=$package_version" >> "$GITHUB_OUTPUT"
+          echo "npm_tag=$npm_tag" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
@@ -260,11 +95,11 @@ jobs:
       - name: 🟢 Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: "20"
+          node-version: "${{ env.NODE_VERSION }}"
           cache: pnpm
-          registry-url: "https://registry.npmjs.org"
+          registry-url: https://registry.npmjs.org/
 
-      - name: 🔄 Update npm
+      - name: ⬆️ Update npm CLI
         run: npm install --global npm@11.5.1
 
       - name: ⚙️ Install dependencies
@@ -273,64 +108,22 @@ jobs:
       - name: 🚧 Build package
         run: pnpm build
 
-      - name: 🧪 Verify package archive
+      - name: 🧪 Verify package archive and installation
         run: |
           set -euo pipefail
           package_dir=$(mktemp -d)
           pnpm pack --pack-destination "$package_dir"
           package_tarball=$(find "$package_dir" -maxdepth 1 -name '*.tgz' -print -quit)
           tar -tzf "$package_tarball" >/dev/null
-
-      - name: 🏷️ Validate release metadata
-        id: metadata
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          MERGE_SHA: ${{ steps.contract.outputs.merge_sha }}
-        run: |
-          set -euo pipefail
-          package_name=$(node -p "require('./package.json').name")
-          package_version=$(node -p "require('./package.json').version")
-          release_tag="v${package_version}"
-          expected_title="Bump version to ${release_tag}"
-
-          if [[ "$PR_TITLE" != "$expected_title" ]]; then
-            echo "::error title=Release title mismatch::Expected '$expected_title', received '$PR_TITLE'."
-            exit 1
-          fi
-          if ! grep -Fq "[${package_version}]" CHANGELOG.md; then
-            echo "::error title=Missing changelog release::CHANGELOG.md does not contain ${package_version}."
-            exit 1
-          fi
-
-          echo "package_name=$package_name" >> "$GITHUB_OUTPUT"
-          echo "package_version=$package_version" >> "$GITHUB_OUTPUT"
-          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-          echo "merge_sha=$MERGE_SHA" >> "$GITHUB_OUTPUT"
-
-      - name: 🔒 Validate release tag state
-        id: tag_state
-        env:
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-          MERGE_SHA: ${{ steps.metadata.outputs.merge_sha }}
-        run: |
-          set -euo pipefail
-          git fetch --tags --force
-          if git rev-parse --verify "${RELEASE_TAG}^{commit}" >/dev/null 2>&1; then
-            existing_sha=$(git rev-list -n 1 "$RELEASE_TAG")
-            if [[ "$existing_sha" != "$MERGE_SHA" ]]; then
-              echo "::error title=Release tag collision::$RELEASE_TAG points to $existing_sha instead of $MERGE_SHA."
-              exit 1
-            fi
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "exists=false" >> "$GITHUB_OUTPUT"
+          cd "$package_dir"
+          echo '{"name":"test-package","version":"1.0.0","private":true}' > package.json
+          pnpm add --save-dev "$package_tarball"
 
       - name: 🔎 Check npm publication state
-        id: npm_state
+        id: npm
         env:
-          PACKAGE_NAME: ${{ steps.metadata.outputs.package_name }}
-          PACKAGE_VERSION: ${{ steps.metadata.outputs.package_version }}
+          PACKAGE_NAME: ${{ steps.release.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.release.outputs.package_version }}
         run: |
           set -euo pipefail
           error_file=$(mktemp)
@@ -357,50 +150,25 @@ jobs:
           cat "$error_file"
           exit "$status"
 
-      - name: 🎉 Publish to npm
-        if: steps.npm_state.outputs.published != 'true'
-        run: npm publish
-
-      - name: 🏷️ Create immutable release tag
-        if: steps.tag_state.outputs.exists != 'true'
+      - name: 🎉 Publish package with npm OIDC
+        if: steps.npm.outputs.published != 'true'
         env:
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-          MERGE_SHA: ${{ steps.metadata.outputs.merge_sha }}
+          NPM_TAG: ${{ steps.release.outputs.npm_tag }}
+        run: npm publish --tag "$NPM_TAG"
+
+      - name: ✅ Verify npm publication
+        env:
+          PACKAGE_NAME: ${{ steps.release.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.release.outputs.package_version }}
+          NPM_TAG: ${{ steps.release.outputs.npm_tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          ALREADY_PUBLISHED: ${{ steps.npm.outputs.published }}
         run: |
           set -euo pipefail
-          git tag "$RELEASE_TAG" "$MERGE_SHA"
-          git push origin "refs/tags/${RELEASE_TAG}"
-
-      - name: 📦 Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-        run: |
-          set -euo pipefail
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "GitHub Release $RELEASE_TAG already exists."
-            exit 0
-          fi
-          gh release create "$RELEASE_TAG" \
-            --verify-tag \
-            --title "Release ${RELEASE_TAG}" \
-            --notes "Automated release ${RELEASE_TAG}."
-
-      - name: ✅ Verify published release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PACKAGE_NAME: ${{ steps.metadata.outputs.package_name }}
-          PACKAGE_VERSION: ${{ steps.metadata.outputs.package_version }}
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-          MERGE_SHA: ${{ steps.metadata.outputs.merge_sha }}
-        run: |
-          set -euo pipefail
-          published_version=
           for attempt in $(seq 1 12); do
-            if published_version=$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --json | jq -r .); then
-              if [[ "$published_version" == "$PACKAGE_VERSION" ]]; then
-                break
-              fi
+            published_version=$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --json 2>/dev/null | jq -r . || true)
+            if [[ "$published_version" == "$PACKAGE_VERSION" ]]; then
+              break
             fi
             if (( attempt == 12 )); then
               echo "::error title=npm verification failed::${PACKAGE_NAME}@${PACKAGE_VERSION} was not visible after 12 attempts."
@@ -408,6 +176,18 @@ jobs:
             fi
             sleep 5
           done
-          gh release view "$RELEASE_TAG" >/dev/null
-          tag_sha=$(git rev-list -n 1 "$RELEASE_TAG")
-          [[ "$tag_sha" == "$MERGE_SHA" ]]
+
+          if [[ "$ALREADY_PUBLISHED" != "true" ]]; then
+            dist_tag_version=$(npm view "$PACKAGE_NAME" "dist-tags.${NPM_TAG}" --json | jq -r .)
+            if [[ "$dist_tag_version" != "$PACKAGE_VERSION" ]]; then
+              echo "::error title=npm dist-tag mismatch::$NPM_TAG points to $dist_tag_version instead of $PACKAGE_VERSION."
+              exit 1
+            fi
+          fi
+
+          {
+            echo "### npm package published"
+            echo "- Package: ${PACKAGE_NAME}@${PACKAGE_VERSION}"
+            echo "- Dist-tag: $NPM_TAG"
+            echo "- Source tag: $RELEASE_TAG"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/create-github-release.workflow.yml
+++ b/.github/workflows/create-github-release.workflow.yml
@@ -112,16 +112,17 @@ jobs:
           fi
 
           if existing_release_json=$(gh release view "$release_tag" --json tagName,isDraft,isPrerelease 2>/dev/null); then
-            git fetch --force origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
-            existing_sha=$(git rev-list -n 1 "$release_tag")
             existing_draft=$(jq -r .isDraft <<<"$existing_release_json")
             existing_prerelease=$(jq -r .isPrerelease <<<"$existing_release_json")
-            if [[ "$existing_sha" != "$release_sha" ]]; then
-              echo "::error title=Release target mismatch::$release_tag points to $existing_sha instead of $release_sha."
-              exit 1
-            fi
             if [[ "$existing_draft" != "false" || "$existing_prerelease" != "$prerelease" ]]; then
               echo "::error title=Release metadata mismatch::$release_tag has draft=$existing_draft and prerelease=$existing_prerelease."
+              exit 1
+            fi
+
+            git fetch --force origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
+            existing_sha=$(git rev-list -n 1 "$release_tag")
+            if [[ "$existing_sha" != "$release_sha" ]]; then
+              echo "::error title=Release target mismatch::$release_tag points to $existing_sha instead of $release_sha."
               exit 1
             fi
             echo "create=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/create-github-release.workflow.yml
+++ b/.github/workflows/create-github-release.workflow.yml
@@ -1,0 +1,236 @@
+name: 🏷️ Create GitHub release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact package.json version to recover as a GitHub Release
+        required: true
+        type: string
+
+permissions: read-all
+
+concurrency:
+  group: create-github-release-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Create immutable GitHub Release
+    if: >-
+      github.event.repository.fork == false &&
+      github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: admin
+    permissions:
+      contents: read
+    env:
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+    steps:
+      - name: 📥 Checkout release commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: 🧭 Resolve changed package version
+        id: candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          REQUESTED_VERSION: ${{ inputs.version || '' }}
+        run: |
+          set -euo pipefail
+
+          read_package_version() {
+            git show "$1:package.json" 2>/dev/null | jq -r .version 2>/dev/null || true
+          }
+
+          current_version=$(node -p "require('./package.json').version")
+          if ! [[ "$current_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error title=Invalid package version::$current_version is not a supported semantic version."
+            exit 1
+          fi
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            requested_version="${REQUESTED_VERSION#v}"
+            if [[ "$requested_version" != "$current_version" ]]; then
+              echo "::error title=Version mismatch::Requested $requested_version but package.json contains $current_version."
+              exit 1
+            fi
+            release_range="$GITHUB_SHA"
+          else
+            zero_sha=0000000000000000000000000000000000000000
+            previous_version=
+            if [[ -n "$BEFORE_SHA" && "$BEFORE_SHA" != "$zero_sha" ]]; then
+              previous_version=$(read_package_version "$BEFORE_SHA")
+            fi
+            if [[ -z "$previous_version" || "$previous_version" == "$current_version" ]]; then
+              echo "create=false" >> "$GITHUB_OUTPUT"
+              echo "package.json version did not change on this push."
+              exit 0
+            fi
+            release_range="${BEFORE_SHA}..${GITHUB_SHA}"
+          fi
+
+          release_sha=
+          while IFS= read -r candidate_sha; do
+            candidate_version=$(read_package_version "$candidate_sha")
+            if [[ "$candidate_version" != "$current_version" ]]; then
+              continue
+            fi
+
+            parent_sha=$(git rev-parse "${candidate_sha}^1" 2>/dev/null || true)
+            parent_version=
+            if [[ -n "$parent_sha" ]]; then
+              parent_version=$(read_package_version "$parent_sha")
+            fi
+            if [[ "$parent_version" != "$current_version" ]]; then
+              release_sha="$candidate_sha"
+              break
+            fi
+          done < <(git rev-list --first-parent "$release_range" -- package.json)
+
+          if [[ -z "$release_sha" ]]; then
+            echo "::error title=Unresolved release commit::No default-branch commit introduced package version $current_version."
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$release_sha" "$GITHUB_SHA"; then
+            echo "::error title=Invalid release commit::$release_sha is not an ancestor of $GITHUB_SHA."
+            exit 1
+          fi
+
+          release_tag="v${current_version}"
+          prerelease=false
+          if [[ "$current_version" == *-* ]]; then
+            prerelease=true
+          fi
+
+          if existing_release_json=$(gh release view "$release_tag" --json tagName,isDraft,isPrerelease 2>/dev/null); then
+            git fetch --force origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
+            existing_sha=$(git rev-list -n 1 "$release_tag")
+            existing_draft=$(jq -r .isDraft <<<"$existing_release_json")
+            existing_prerelease=$(jq -r .isPrerelease <<<"$existing_release_json")
+            if [[ "$existing_sha" != "$release_sha" ]]; then
+              echo "::error title=Release target mismatch::$release_tag points to $existing_sha instead of $release_sha."
+              exit 1
+            fi
+            if [[ "$existing_draft" != "false" || "$existing_prerelease" != "$prerelease" ]]; then
+              echo "::error title=Release metadata mismatch::$release_tag has draft=$existing_draft and prerelease=$existing_prerelease."
+              exit 1
+            fi
+            echo "create=false" >> "$GITHUB_OUTPUT"
+            echo "GitHub Release $release_tag already exists with the expected target and metadata."
+            exit 0
+          fi
+
+          if git rev-parse --verify "${release_tag}^{commit}" >/dev/null 2>&1; then
+            existing_sha=$(git rev-list -n 1 "$release_tag")
+            if [[ "$existing_sha" != "$release_sha" ]]; then
+              echo "::error title=Release tag collision::$release_tag points to $existing_sha instead of $release_sha."
+              exit 1
+            fi
+          fi
+
+          echo "create=true" >> "$GITHUB_OUTPUT"
+          echo "version=$current_version" >> "$GITHUB_OUTPUT"
+          echo "tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
+
+      - name: 🔐 Validate release publisher identity
+        if: steps.candidate.outputs.create == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error title=Missing release secret::Configure PAT_FINE in the admin environment."
+            exit 1
+          fi
+          actor_username=$(gh api user --jq .login)
+          if [[ "$actor_username" != "$GITHUB_REPOSITORY_OWNER" ]]; then
+            echo "::error title=Invalid release actor::PAT_FINE authenticates as $actor_username instead of $GITHUB_REPOSITORY_OWNER."
+            exit 1
+          fi
+
+      - name: 🏷️ Create immutable release tag
+        if: steps.candidate.outputs.create == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+          RELEASE_TAG: ${{ steps.candidate.outputs.tag }}
+          RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+            existing_sha=$(git rev-list -n 1 "$RELEASE_TAG")
+            if [[ "$existing_sha" != "$RELEASE_SHA" ]]; then
+              echo "::error title=Release tag collision::$RELEASE_TAG points to $existing_sha instead of $RELEASE_SHA."
+              exit 1
+            fi
+            echo "Tag $RELEASE_TAG already points to the release commit."
+            exit 0
+          fi
+
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${RELEASE_TAG}" \
+            -f sha="$RELEASE_SHA" >/dev/null
+
+      - name: 📦 Publish GitHub Release
+        if: steps.candidate.outputs.create == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+          RELEASE_TAG: ${{ steps.candidate.outputs.tag }}
+          IS_PRERELEASE: ${{ steps.candidate.outputs.prerelease }}
+          RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "GitHub Release $RELEASE_TAG already exists."
+            exit 0
+          fi
+
+          release_args=(
+            "$RELEASE_TAG"
+            --verify-tag
+            --target "$RELEASE_SHA"
+            --title "Release $RELEASE_TAG"
+            --generate-notes
+          )
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            release_args+=(--prerelease)
+          fi
+          gh release create "${release_args[@]}"
+
+      - name: ✅ Verify GitHub Release
+        if: steps.candidate.outputs.create == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+          RELEASE_TAG: ${{ steps.candidate.outputs.tag }}
+          IS_PRERELEASE: ${{ steps.candidate.outputs.prerelease }}
+          RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          release_json=$(gh release view "$RELEASE_TAG" --json tagName,isDraft,isPrerelease,url)
+          [[ "$(jq -r .tagName <<<"$release_json")" == "$RELEASE_TAG" ]]
+          [[ "$(jq -r .isDraft <<<"$release_json")" == "false" ]]
+          [[ "$(jq -r .isPrerelease <<<"$release_json")" == "$IS_PRERELEASE" ]]
+
+          git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          tag_sha=$(git rev-list -n 1 "$RELEASE_TAG")
+          [[ "$tag_sha" == "$RELEASE_SHA" ]]
+
+          release_url=$(jq -r .url <<<"$release_json")
+          {
+            echo "### GitHub Release created"
+            echo "- Release: $release_url"
+            echo "- Tag: $RELEASE_TAG"
+            echo "- Commit: $RELEASE_SHA"
+            echo "- npm delivery: release.published event"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -29,6 +29,7 @@ jobs:
       issues: write
       pull-requests: write
     env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_URL: ${{ github.event.pull_request.html_url }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
@@ -113,9 +114,12 @@ jobs:
             exit 0
           fi
 
-          gh pr review "$PR_URL" \
-            --approve \
-            --body "Approved automatically: patch or minor update."
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+            -f commit_id="$HEAD_SHA" \
+            -f event=APPROVE \
+            -f body="Approved automatically: patch or minor update." >/dev/null
 
       - name: Enable squash auto-merge
         if: steps.policy.outputs.eligible == 'true'

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -15,86 +15,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  approve-release:
-    name: Approve and queue trusted release pull request
-    if: >-
-      github.event.repository.fork == false &&
-      contains(github.event.pull_request.labels.*.name, 'auto-release') &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.base.ref == github.event.repository.default_branch &&
-      github.event.pull_request.user.login == github.repository_owner
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: write
-      pull-requests: write
-    env:
-      PR_URL: ${{ github.event.pull_request.html_url }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-    steps:
-      - name: Approve current release head
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            const { owner, repo } = context.repo;
-            const pullNumber = context.payload.pull_request.number;
-            const headSha = context.payload.pull_request.head.sha;
-            const reviews = await github.paginate(
-              github.rest.pulls.listReviews,
-              { owner, repo, pull_number: pullNumber, per_page: 100 },
-            );
-            const alreadyApproved = reviews.some(
-              (review) =>
-                review.user?.login === 'github-actions[bot]' &&
-                review.state === 'APPROVED' &&
-                review.commit_id === headSha,
-            );
-
-            if (alreadyApproved) {
-              core.info(`Release PR #${pullNumber} is already approved for ${headSha}.`);
-              return;
-            }
-
-            try {
-              await github.rest.pulls.createReview({
-                owner,
-                repo,
-                pull_number: pullNumber,
-                commit_id: headSha,
-                event: 'APPROVE',
-                body: 'Approved by the trusted release workflow contract.',
-              });
-            } catch (error) {
-              if (error.status === 403) {
-                core.setFailed(
-                  'GitHub Actions cannot approve pull requests. Enable “Allow GitHub Actions to create and approve pull requests” under Settings → Actions → General → Workflow permissions.',
-                );
-                return;
-              }
-              throw error;
-            }
-
-      - name: Enable squash auto-merge
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          current_head=$(gh pr view "$PR_URL" --json headRefOid --jq .headRefOid)
-          if [[ "$current_head" != "$HEAD_SHA" ]]; then
-            echo "Skipping stale event for $HEAD_SHA; current head is $current_head."
-            exit 0
-          fi
-          auto_merge_enabled=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')
-          if [[ "$auto_merge_enabled" == "true" ]]; then
-            echo "Auto-merge is already enabled for the current release pull request."
-            exit 0
-          fi
-          gh pr merge "$PR_URL" \
-            --auto \
-            --squash \
-            --match-head-commit "$HEAD_SHA"
-
   dependabot:
     name: Validate and queue eligible updates
     if: >-
@@ -175,15 +95,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PAT_FINE }}
         run: |
-          if [ -z "$GH_TOKEN" ]; then
+          set -euo pipefail
+          if [[ -z "$GH_TOKEN" ]]; then
             echo "::error title=Missing Dependabot secret::Configure PAT_FINE as a Dependabot repository secret. It must be a fine-grained token for this repository with Pull requests read/write permission."
             exit 1
           fi
 
           authenticated_login=$(gh api user --jq .login)
-          if [ "$authenticated_login" != "$GITHUB_REPOSITORY_OWNER" ]; then
+          if [[ "$authenticated_login" != "$GITHUB_REPOSITORY_OWNER" ]]; then
             echo "::error title=Invalid Dependabot approval actor::PAT_FINE authenticates as $authenticated_login, but this repository requires $GITHUB_REPOSITORY_OWNER."
             exit 1
+          fi
+
+          current_head=$(gh pr view "$PR_URL" --json headRefOid --jq .headRefOid)
+          if [[ "$current_head" != "$HEAD_SHA" ]]; then
+            echo "Skipping stale Dependabot event for $HEAD_SHA; current head is $current_head."
+            exit 0
           fi
 
           gh pr review "$PR_URL" \
@@ -195,6 +122,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+          current_head=$(gh pr view "$PR_URL" --json headRefOid --jq .headRefOid)
+          if [[ "$current_head" != "$HEAD_SHA" ]]; then
+            echo "Skipping stale Dependabot event for $HEAD_SHA; current head is $current_head."
+            exit 0
+          fi
           gh pr merge "$PR_URL" \
             --auto \
             --squash \

--- a/.github/workflows/prepare-release.workflow.yml
+++ b/.github/workflows/prepare-release.workflow.yml
@@ -1,12 +1,13 @@
-name: 🏗️ Prepare release
+name: 🏗️ Prepare release pull request
 
 on:
-  schedule:
-    - cron: "0 7 * * *"
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       force:
-        description: "Force release"
+        description: Create a release pull request below the commit threshold
         required: true
         default: "no"
         type: choice
@@ -14,20 +15,22 @@ on:
           - "yes"
           - "no"
       strategy:
-        description: "Release strategy (if force=yes):\nmajor→2.0.0 • minor→1.1.0 • patch→1.0.1\npremajor→2.0.0-0 • preminor→1.1.0-0 • prepatch→1.0.1-0\nprerelease→1.0.1-0"
+        description: Release strategy when force is enabled
         required: true
+        default: auto
         type: choice
         options:
-          - "major"
-          - "minor"
-          - "patch"
-          - "premajor"
-          - "preminor"
-          - "prepatch"
-          - "prerelease"
+          - auto
+          - major
+          - minor
+          - patch
+          - premajor
+          - preminor
+          - prepatch
+          - prerelease
       dry_run:
-        description: "Do everything except push, PR and publish"
-        required: false
+        description: Calculate and validate without pushing a branch or creating a pull request
+        required: true
         default: "false"
         type: choice
         options:
@@ -43,13 +46,16 @@ concurrency:
 env:
   NODE_VERSION: ${{ vars.NODE_VERSION }}
   PNPM_VERSION: ${{ vars.PNPM_VERSION }}
+  MINIMUM_COMMITS: "4"
 
-run-name: 🏗️ Prepare release${{ github.event.inputs.dry_run == 'true' && ' (dry)' || '' }}
+run-name: 🏗️ Prepare release${{ inputs.dry_run == 'true' && ' (dry run)' || '' }}
 
 jobs:
-  prepare-release:
-    if: github.actor == github.repository_owner || github.actor == 'github-actions'
-    name: 🚀 Prepare release${{ github.event.inputs.dry_run == 'true' && ' (dry)' || '' }}
+  prepare:
+    name: Prepare trusted release pull request
+    if: >-
+      github.event.repository.fork == false &&
+      github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: admin
@@ -58,192 +64,253 @@ jobs:
       pull-requests: read
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      FORCE_RELEASE: ${{ inputs.force || 'no' }}
+      REQUESTED_STRATEGY: ${{ inputs.strategy || 'auto' }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
     steps:
-      - name: 📥 Checkout code
+      - name: 📥 Checkout trusted default branch
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_FINE }}
+          persist-credentials: false
 
-      - name: 🕵️ Check release threshold
-        id: check_commits
-        env:
-          FORCE_RELEASE: ${{ github.event.inputs.force }}
-        run: |
-          set -euo pipefail
-          minimum_commits=4
+      - name: 🌿 Attach exact default-branch commit
+        run: git checkout -B "$DEFAULT_BRANCH" "$GITHUB_SHA"
 
-          if [[ "$FORCE_RELEASE" == "yes" ]]; then
-            echo "enough_commits=true" >> "$GITHUB_OUTPUT"
-            echo "Force release is enabled. Skipping commit threshold."
-            exit 0
-          fi
-
-          last_tag=$(git for-each-ref --sort=-version:refname --count=1 --format='%(refname:short)' refs/tags)
-          if [[ -z "$last_tag" ]]; then
-            commit_count=$(git rev-list --count HEAD)
-            echo "No release tag found. Counting all commits."
-          else
-            commit_count=$(git rev-list --count "${last_tag}..HEAD")
-            echo "Last tag: $last_tag"
-          fi
-          echo "Commits since release baseline: $commit_count"
-
-          if (( commit_count < minimum_commits )); then
-            echo "enough_commits=false" >> "$GITHUB_OUTPUT"
-            echo "Fewer than $minimum_commits commits are available. No release PR will be created."
-            exit 0
-          fi
-
-          echo "enough_commits=true" >> "$GITHUB_OUTPUT"
-
-      - name: 🎫 Configure Git
-        if: steps.check_commits.outputs.enough_commits == 'true'
+      - name: 🔐 Validate release automation identity
+        id: automation
         env:
           GH_TOKEN: ${{ secrets.PAT_FINE }}
         run: |
           set -euo pipefail
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error title=Missing release secret::Configure PAT_FINE in the admin environment."
+            exit 1
+          fi
+
           actor_username=$(gh api user --jq .login)
+          if [[ "$actor_username" != "$GITHUB_REPOSITORY_OWNER" ]]; then
+            echo "::error title=Invalid release actor::PAT_FINE authenticates as $actor_username instead of $GITHUB_REPOSITORY_OWNER."
+            exit 1
+          fi
+
+          labels=$(gh label list --limit 100 --json name --jq '.[].name')
+          if ! grep -Fxq auto-release <<<"$labels"; then
+            echo "::error title=Missing release label::Create the auto-release label before enabling automated releases."
+            exit 1
+          fi
+
           actor_email=$(gh api user --jq '.email // empty')
           if [[ -z "$actor_email" ]]; then
             actor_email="${actor_username}@users.noreply.github.com"
           fi
-          echo "ACTOR_USERNAME=$actor_username" >> "$GITHUB_ENV"
-          git config --global user.name "$actor_username"
-          git config --global user.email "$actor_email"
+
+          git config user.name "$actor_username"
+          git config user.email "$actor_email"
+          echo "actor_username=$actor_username" >> "$GITHUB_OUTPUT"
+
+      - name: 🧭 Resolve release baseline
+        id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+        run: |
+          set -euo pipefail
+          current_version=$(node -p "require('./package.json').version")
+          current_tag="v${current_version}"
+
+          if ! current_release_json=$(gh release view "$current_tag" --json tagName,isDraft,isPrerelease 2>/dev/null); then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "Current package version $current_version has no GitHub Release yet. Waiting for release recovery instead of preparing another version."
+            exit 0
+          fi
+
+          expected_prerelease=false
+          if [[ "$current_version" == *-* ]]; then
+            expected_prerelease=true
+          fi
+          current_release_draft=$(jq -r .isDraft <<<"$current_release_json")
+          current_release_prerelease=$(jq -r .isPrerelease <<<"$current_release_json")
+          if [[ "$current_release_draft" != "false" || "$current_release_prerelease" != "$expected_prerelease" ]]; then
+            echo "::error title=Release metadata mismatch::$current_tag has draft=$current_release_draft and prerelease=$current_release_prerelease."
+            exit 1
+          fi
+
+          latest_tag=$(gh release list --exclude-drafts --limit 1 --json tagName --jq '.[0].tagName // empty')
+          if [[ -z "$latest_tag" ]]; then
+            echo "::error title=Missing release baseline::package.json is version $current_version, but no published GitHub Release was found."
+            exit 1
+          fi
+          if [[ "$latest_tag" != "$current_tag" ]]; then
+            echo "::error title=Release drift::package.json contains $current_version while the latest GitHub Release is $latest_tag."
+            exit 1
+          fi
+
+          git fetch --force origin "refs/tags/${current_tag}:refs/tags/${current_tag}"
+          release_sha=$(git rev-list -n 1 "$current_tag")
+          if ! git merge-base --is-ancestor "$release_sha" HEAD; then
+            echo "::error title=Invalid release baseline::$current_tag is not an ancestor of the default branch."
+            exit 1
+          fi
+          release_version=$(git show "${release_sha}:package.json" | jq -r .version)
+          if [[ "$release_version" != "$current_version" ]]; then
+            echo "::error title=Release package mismatch::$current_tag targets package version $release_version instead of $current_version."
+            exit 1
+          fi
+
+          existing_pr=$(gh pr list \
+            --limit 100 \
+            --state open \
+            --base "$DEFAULT_BRANCH" \
+            --label auto-release \
+            --author "$GITHUB_REPOSITORY_OWNER" \
+            --json url,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release/"))][0].url // empty')
+          if [[ -n "$existing_pr" ]]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "Trusted release pull request already open: $existing_pr"
+            exit 0
+          fi
+
+          commit_count=$(git rev-list --count "${current_tag}..HEAD")
+          echo "Commits since $current_tag: $commit_count"
+          if [[ "$FORCE_RELEASE" != "yes" && "$commit_count" -lt "$MINIMUM_COMMITS" ]]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "At least $MINIMUM_COMMITS commits are required."
+            exit 0
+          fi
+
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+          echo "current_tag=$current_tag" >> "$GITHUB_OUTPUT"
+          echo "commit_count=$commit_count" >> "$GITHUB_OUTPUT"
 
       - name: 📦 Setup pnpm
-        if: steps.check_commits.outputs.enough_commits == 'true'
+        if: steps.baseline.outputs.ready == 'true'
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: "${{ env.PNPM_VERSION }}"
           run_install: false
 
       - name: 🟢 Setup Node.js
-        if: steps.check_commits.outputs.enough_commits == 'true'
+        if: steps.baseline.outputs.ready == 'true'
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: "20"
+          node-version: "${{ env.NODE_VERSION }}"
           cache: pnpm
-          registry-url: "https://registry.npmjs.org"
 
-      - name: 🔄 Update npm
-        if: steps.check_commits.outputs.enough_commits == 'true'
+      - name: ⬆️ Update npm CLI
+        if: steps.baseline.outputs.ready == 'true'
         run: npm install --global npm@11.5.1
 
       - name: ⚙️ Install dependencies
-        if: steps.check_commits.outputs.enough_commits == 'true'
+        if: steps.baseline.outputs.ready == 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: 🚧 Run build
-        if: steps.check_commits.outputs.enough_commits == 'true'
+      - name: 🚧 Build package
+        if: steps.baseline.outputs.ready == 'true'
         run: pnpm build
 
-      - name: 🧪 Install package test
-        if: steps.check_commits.outputs.enough_commits == 'true'
+      - name: 🧪 Verify package installation
+        if: steps.baseline.outputs.ready == 'true'
         run: |
           set -euo pipefail
-          test_dir=$(mktemp -d)
-          pnpm pack --pack-destination "$test_dir"
-          cd "$test_dir"
+          package_dir=$(mktemp -d)
+          pnpm pack --pack-destination "$package_dir"
+          package_tarball=$(find "$package_dir" -maxdepth 1 -name '*.tgz' -print -quit)
+          tar -tzf "$package_tarball" >/dev/null
+          cd "$package_dir"
           echo '{"name":"test-package","version":"1.0.0","private":true}' > package.json
-          package_tarball=$(find . -maxdepth 1 -name '*.tgz' -print -quit)
           pnpm add --save-dev "$package_tarball"
 
-      - name: 🆙 Dry run release
-        if: steps.check_commits.outputs.enough_commits == 'true' && github.event.inputs.dry_run == 'true'
+      - name: 🧭 Resolve release strategy
+        if: steps.baseline.outputs.ready == 'true'
+        id: strategy
         env:
-          REQUESTED_STRATEGY: ${{ github.event.inputs.strategy }}
+          CURRENT_TAG: ${{ steps.baseline.outputs.current_tag }}
         run: |
           set -euo pipefail
-          git checkout "$DEFAULT_BRANCH"
-          git pull --ff-only origin "$DEFAULT_BRANCH"
-          strategy=${REQUESTED_STRATEGY:-patch}
-          pnpm release --release-as "$strategy" --dry-run
+          strategy="$REQUESTED_STRATEGY"
+          if [[ "$strategy" == "auto" ]]; then
+            strategy=patch
+            if git log "${CURRENT_TAG}..HEAD" --format='%s%n%b' | grep -Eq '(^[a-z]+(\([^)]*\))?!:|^BREAKING CHANGE:)'; then
+              strategy=major
+            elif git log "${CURRENT_TAG}..HEAD" --format='%s' | grep -Eq '^feat(\([^)]*\))?:'; then
+              strategy=minor
+            fi
+          fi
+          echo "value=$strategy" >> "$GITHUB_OUTPUT"
 
-      - name: 📝 Prepare release pull request
-        if: steps.check_commits.outputs.enough_commits == 'true' && github.event.inputs.dry_run != 'true'
-        id: prepare_release
+      - name: 🧪 Calculate release without delivery
+        if: steps.baseline.outputs.ready == 'true' && env.DRY_RUN == 'true'
+        env:
+          STRATEGY: ${{ steps.strategy.outputs.value }}
+        run: pnpm release --release-as "$STRATEGY" --dry-run
+
+      - name: 📝 Create release pull request
+        if: steps.baseline.outputs.ready == 'true' && env.DRY_RUN != 'true'
+        id: pull_request
         env:
           GH_TOKEN: ${{ secrets.PAT_FINE }}
-          REQUESTED_STRATEGY: ${{ github.event.inputs.strategy }}
+          STRATEGY: ${{ steps.strategy.outputs.value }}
+          ACTOR_USERNAME: ${{ steps.automation.outputs.actor_username }}
+          COMMIT_COUNT: ${{ steps.baseline.outputs.commit_count }}
         run: |
           set -euo pipefail
-          release_branch="release/${GITHUB_RUN_NUMBER}"
-
-          if git ls-remote --exit-code --heads origin "$release_branch" >/dev/null 2>&1; then
-            existing_pr=$(gh pr list --head "$release_branch" --base "$DEFAULT_BRANCH" --state open --json url --jq '.[0].url // empty')
-            if [[ -z "$existing_pr" ]]; then
-              echo "::error title=Release branch collision::$release_branch exists without an open pull request."
-              exit 1
-            fi
-            head_sha=$(gh pr view "$existing_pr" --json headRefOid --jq .headRefOid)
-            release_title=$(gh pr view "$existing_pr" --json title --jq .title)
-            if [[ "$release_title" != "Bump version to v"* ]]; then
-              echo "::error title=Invalid existing release PR::$existing_pr has unexpected title '$release_title'."
-              exit 1
-            fi
-            release_tag=${release_title#Bump version to }
-            git fetch origin "refs/heads/${release_branch}:refs/remotes/origin/${release_branch}"
-            remote_head=$(git rev-parse "refs/remotes/origin/${release_branch}")
-            if [[ "$remote_head" != "$head_sha" ]]; then
-              echo "::error title=Release head mismatch::$release_branch points to $remote_head but the pull request reports $head_sha."
-              exit 1
-            fi
-            head_version=$(git show "${remote_head}:package.json" | jq -r .version)
-            if [[ "v${head_version}" != "$release_tag" ]]; then
-              echo "::error title=Release version mismatch::PR title resolves to $release_tag but package.json contains $head_version."
-              exit 1
-            fi
-            gh pr edit "$existing_pr" --add-label auto-release --add-assignee "$ACTOR_USERNAME"
-            echo "pr_url=$existing_pr" >> "$GITHUB_OUTPUT"
-            echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-            echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git checkout "$DEFAULT_BRANCH"
-          git pull --ff-only origin "$DEFAULT_BRANCH"
-          git checkout -b "$release_branch"
-          strategy=${REQUESTED_STRATEGY:-patch}
-          pnpm release --release-as "$strategy"
+          pnpm release --release-as "$STRATEGY"
 
           release_version=$(node -p "require('./package.json').version")
           release_tag="v${release_version}"
+          release_branch="release/${release_tag}"
+
           if ! git rev-parse --verify "refs/tags/${release_tag}" >/dev/null 2>&1; then
-            echo "::error title=Missing local release tag::standard-version did not create ${release_tag}."
+            echo "::error title=Missing generated tag::standard-version did not create $release_tag."
             exit 1
           fi
           git tag -d "$release_tag"
-          if git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1; then
-            echo "::error title=Remote release tag collision::$release_tag already exists on origin."
+
+          if gh release view "$release_tag" >/dev/null 2>&1; then
+            echo "::error title=Release already exists::GitHub Release $release_tag already exists."
             exit 1
           fi
-          git push origin "HEAD:refs/heads/${release_branch}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1; then
+            echo "::error title=Tag collision::Remote tag $release_tag already exists."
+            exit 1
+          fi
+          if git ls-remote --exit-code --heads origin "refs/heads/${release_branch}" >/dev/null 2>&1; then
+            echo "::error title=Release branch collision::$release_branch already exists."
+            exit 1
+          fi
+
+          git branch -m "$release_branch"
+          authorization=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
+          echo "::add-mask::$authorization"
+          git -c http.extraheader="Authorization: Basic $authorization" \
+            push origin "HEAD:refs/heads/${release_branch}"
 
           pr_url=$(gh pr create \
             --base "$DEFAULT_BRANCH" \
             --head "$release_branch" \
             --title "Bump version to ${release_tag}" \
-            --body "Bumps version to ${release_tag}. Publication starts only after this pull request is merged by the repository requirements.")
-          gh pr edit "$pr_url" --add-label auto-release --add-assignee "$ACTOR_USERNAME"
+            --label auto-release \
+            --assignee "$ACTOR_USERNAME" \
+            --body "Automated release from ${COMMIT_COUNT} commits. The trusted release workflow validates and approves this exact head, then repository requirements control squash auto-merge.")
 
           head_sha=$(git rev-parse HEAD)
-          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+          echo "url=$pr_url" >> "$GITHUB_OUTPUT"
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
           echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
 
       - name: 📋 Report release pull request
-        if: steps.prepare_release.outputs.pr_url != ''
+        if: steps.pull_request.outputs.url != ''
         env:
-          PR_URL: ${{ steps.prepare_release.outputs.pr_url }}
-          HEAD_SHA: ${{ steps.prepare_release.outputs.head_sha }}
-          RELEASE_TAG: ${{ steps.prepare_release.outputs.release_tag }}
+          PR_URL: ${{ steps.pull_request.outputs.url }}
+          HEAD_SHA: ${{ steps.pull_request.outputs.head_sha }}
+          RELEASE_TAG: ${{ steps.pull_request.outputs.release_tag }}
         run: |
           {
-            echo "### Release pull request prepared"
+            echo "### Release pull request created"
             echo "- Pull request: $PR_URL"
             echo "- Head: $HEAD_SHA"
             echo "- Version: $RELEASE_TAG"
-            echo "- Delivery: repository requirements and auto-merge"
+            echo "- Approval: trusted release contract workflow"
+            echo "- Merge: repository requirements and squash auto-merge"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-auto-merge.workflow.yml
+++ b/.github/workflows/release-auto-merge.workflow.yml
@@ -158,7 +158,7 @@ jobs:
               await readRepositoryFile('package.json', pullRequest.head.sha),
             );
             const basePackageJson = JSON.parse(
-              await readRepositoryFile('package.json', pullRequest.base.sha),
+              await readRepositoryFile('package.json', defaultBranch),
             );
             const parsedBaseVersion = parseSemver(basePackageJson.version);
             if (

--- a/.github/workflows/release-auto-merge.workflow.yml
+++ b/.github/workflows/release-auto-merge.workflow.yml
@@ -1,0 +1,281 @@
+name: 🔐 Trusted release auto-merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: trusted-release-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  approve-release:
+    name: Validate, approve, and queue release pull request
+    if: >-
+      github.event.repository.fork == false &&
+      contains(github.event.pull_request.labels.*.name, 'auto-release') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == github.repository_owner &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: admin
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: 🔐 Validate current release pull request
+        id: contract
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pullNumber = context.payload.pull_request.number;
+            const eventHeadSha = context.payload.pull_request.head.sha;
+            const repositoryOwner = context.payload.repository.owner.login;
+            const defaultBranch = context.payload.repository.default_branch;
+            const semverPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?$/;
+
+            const parseSemver = (value) => {
+              const match = semverPattern.exec(value);
+              if (!match) return null;
+              return {
+                core: [Number(match[1]), Number(match[2]), Number(match[3])],
+                prerelease: match[4]?.split('.') ?? [],
+              };
+            };
+
+            const compareSemver = (left, right) => {
+              for (let index = 0; index < left.core.length; index += 1) {
+                if (left.core[index] !== right.core[index]) {
+                  return left.core[index] > right.core[index] ? 1 : -1;
+                }
+              }
+              if (left.prerelease.length === 0 || right.prerelease.length === 0) {
+                if (left.prerelease.length === right.prerelease.length) return 0;
+                return left.prerelease.length === 0 ? 1 : -1;
+              }
+              const length = Math.max(left.prerelease.length, right.prerelease.length);
+              for (let index = 0; index < length; index += 1) {
+                const leftIdentifier = left.prerelease[index];
+                const rightIdentifier = right.prerelease[index];
+                if (leftIdentifier === undefined) return -1;
+                if (rightIdentifier === undefined) return 1;
+                if (leftIdentifier === rightIdentifier) continue;
+                const leftNumeric = /^\d+$/.test(leftIdentifier);
+                const rightNumeric = /^\d+$/.test(rightIdentifier);
+                if (leftNumeric && rightNumeric) {
+                  return Number(leftIdentifier) > Number(rightIdentifier) ? 1 : -1;
+                }
+                if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+                return leftIdentifier > rightIdentifier ? 1 : -1;
+              }
+              return 0;
+            };
+
+            const readRepositoryFile = async (path, ref) => {
+              const response = await github.rest.repos.getContent({ owner, repo, path, ref });
+              if (Array.isArray(response.data) || response.data.type !== 'file') {
+                throw new Error(`${path} did not resolve to a repository file at ${ref}.`);
+              }
+              return Buffer.from(response.data.content, 'base64').toString('utf8');
+            };
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+
+            if (pullRequest.head.sha !== eventHeadSha) {
+              core.notice(
+                `Skipping stale event for ${eventHeadSha}; current head is ${pullRequest.head.sha}.`,
+              );
+              core.setOutput('eligible', 'false');
+              return;
+            }
+
+            const titlePrefix = 'Bump version to v';
+            if (!pullRequest.title.startsWith(titlePrefix)) {
+              core.setFailed(`Unexpected release pull request title: ${pullRequest.title}`);
+              return;
+            }
+            const version = pullRequest.title.slice(titlePrefix.length);
+            const parsedVersion = parseSemver(version);
+            if (!parsedVersion || pullRequest.title !== `${titlePrefix}${version}`) {
+              core.setFailed(`Invalid release version in title: ${pullRequest.title}`);
+              return;
+            }
+
+            const expectedBranch = `release/v${version}`;
+            const labels = pullRequest.labels.map((label) =>
+              typeof label === 'string' ? label : label.name,
+            );
+            const trustedMetadata =
+              pullRequest.head.repo?.full_name === `${owner}/${repo}` &&
+              pullRequest.user?.login === repositoryOwner &&
+              pullRequest.base.ref === defaultBranch &&
+              pullRequest.head.ref === expectedBranch &&
+              labels.includes('auto-release');
+
+            if (!trustedMetadata) {
+              core.setFailed('Release pull request metadata violates the trusted release contract.');
+              return;
+            }
+
+            const changedFiles = (
+              await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pullNumber,
+                per_page: 100,
+              })
+            )
+              .map((file) => file.filename)
+              .sort();
+            const expectedFiles = ['CHANGELOG.md', 'package.json'];
+            if (JSON.stringify(changedFiles) !== JSON.stringify(expectedFiles)) {
+              core.setFailed(
+                `Expected only ${expectedFiles.join(', ')}, received ${changedFiles.join(', ')}.`,
+              );
+              return;
+            }
+
+            const packageJson = JSON.parse(
+              await readRepositoryFile('package.json', pullRequest.head.sha),
+            );
+            const basePackageJson = JSON.parse(
+              await readRepositoryFile('package.json', pullRequest.base.sha),
+            );
+            const parsedBaseVersion = parseSemver(basePackageJson.version);
+            if (
+              packageJson.name !== 'typeorm-test-db' ||
+              basePackageJson.name !== 'typeorm-test-db' ||
+              packageJson.version !== version ||
+              !parsedBaseVersion ||
+              compareSemver(parsedVersion, parsedBaseVersion) <= 0
+            ) {
+              core.setFailed(
+                `Expected a monotonic typeorm-test-db version bump from ${basePackageJson.version} to ${version}.`,
+              );
+              return;
+            }
+
+            const changelog = await readRepositoryFile('CHANGELOG.md', pullRequest.head.sha);
+            if (!changelog.includes(`[${version}]`)) {
+              core.setFailed(`CHANGELOG.md does not contain the release entry [${version}].`);
+              return;
+            }
+
+            try {
+              await github.rest.repos.getReleaseByTag({ owner, repo, tag: `v${version}` });
+              core.setFailed(`GitHub Release v${version} already exists.`);
+              return;
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+            try {
+              await github.rest.git.getRef({ owner, repo, ref: `tags/v${version}` });
+              core.setFailed(`Git tag v${version} already exists.`);
+              return;
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+            const alreadyApproved = reviews.some(
+              (review) =>
+                review.user?.login === 'github-actions[bot]' &&
+                review.state === 'APPROVED' &&
+                review.commit_id === pullRequest.head.sha,
+            );
+
+            core.setOutput('eligible', 'true');
+            core.setOutput('head_sha', pullRequest.head.sha);
+            core.setOutput('already_approved', String(alreadyApproved));
+
+      - name: ✅ Approve current release head
+        if: >-
+          steps.contract.outputs.eligible == 'true' &&
+          steps.contract.outputs.already_approved != 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          VALIDATED_HEAD_SHA: ${{ steps.contract.outputs.head_sha }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pullNumber = context.payload.pull_request.number;
+            const validatedHeadSha = process.env.VALIDATED_HEAD_SHA;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+            if (pullRequest.head.sha !== validatedHeadSha) {
+              core.notice(
+                `Skipping stale approval for ${validatedHeadSha}; current head is ${pullRequest.head.sha}.`,
+              );
+              return;
+            }
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number: pullNumber,
+              commit_id: validatedHeadSha,
+              event: 'APPROVE',
+              body: 'Approved by the trusted release workflow contract.',
+            });
+
+      - name: 🔓 Enable squash auto-merge
+        if: steps.contract.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+          VALIDATED_HEAD_SHA: ${{ steps.contract.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error title=Missing release secret::Configure PAT_FINE in the admin environment."
+            exit 1
+          fi
+
+          actor_username=$(gh api user --jq .login)
+          if [[ "$actor_username" != "$GITHUB_REPOSITORY_OWNER" ]]; then
+            echo "::error title=Invalid release actor::PAT_FINE authenticates as $actor_username instead of $GITHUB_REPOSITORY_OWNER."
+            exit 1
+          fi
+
+          current_head=$(gh pr view "$PR_URL" --json headRefOid --jq .headRefOid)
+          if [[ "$current_head" != "$EVENT_HEAD_SHA" || "$current_head" != "$VALIDATED_HEAD_SHA" ]]; then
+            echo "Skipping stale release event; current head is $current_head."
+            exit 0
+          fi
+
+          auto_merge_enabled=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')
+          if [[ "$auto_merge_enabled" == "true" ]]; then
+            echo "Auto-merge is already enabled for the current release pull request."
+            exit 0
+          fi
+
+          gh pr merge "$PR_URL" \
+            --auto \
+            --squash \
+            --match-head-commit "$current_head"


### PR DESCRIPTION
## What

- trigger release preparation after every default-branch push while preserving the four-commit threshold and explicit dry-run/strategy controls
- create owner-authored `release/v<version>` pull requests without publishing or creating remote tags
- validate release pull requests from the trusted default-branch workflow definition and bind approval/auto-merge to the exact live head
- create immutable GitHub Releases from the exact default-branch commit that introduced the package version
- keep `.github/workflows/auto-release.workflow.yml` and `name: 🔄 Auto release` intact as the npm Trusted Publisher identity
- publish npm packages only from `release.published`, allowing manual and automated GitHub Releases to share the same OIDC path
- keep Dependabot policy separate from release pull-request policy

## Why

Release preparation, repository-controlled merge eligibility, GitHub Release creation, and npm publication are separate state transitions. The previous workflow coupled npm delivery to pull-request closure and used scheduled preparation. The event-driven split removes that coupling and reuses the production path proven in `fastypest`.

## Security and integrity

- privileged release validation uses `pull_request_target` without checking out or executing pull-request code
- release pull requests must be same-repository, owner-authored, target the live default branch, use the exact `release/v<version>` branch and title, contain only `CHANGELOG.md` and `package.json`, and provide a strict monotonic SemVer bump
- event and live head SHAs must match before approval and before enabling squash auto-merge
- Dependabot approval is created through the review API with `commit_id` set to the validated head SHA
- release monotonicity is checked against the live default-branch package version rather than the pull request's recorded base SHA
- draft/prerelease metadata is rejected before attempting to fetch a potentially absent tag
- repository requirements remain the merge authority; workflows do not enumerate or poll check runs
- the owner-scoped `PAT_FINE` is restricted to the `admin` environment and its authenticated identity is verified before event-emitting transitions
- tags are immutable; collisions and release metadata drift fail closed
- npm publication uses OIDC only, validates package identity, tag/version equality, prerelease metadata, and default-branch ancestry, and has no token fallback
- all third-party Actions are pinned to full commit SHAs

## Existing release PR

PR #244 (`release/1`, v1.0.58) was created by the previous pipeline and is not modified or merged by this implementation. Preparation no-ops while a trusted release PR is already open. A later version-changing merge is handled by the new GitHub Release and npm stages independently of the old branch name.

## CodeRabbit review disposition

PR #245 received no CodeRabbit inline findings. The three valid safety findings discovered in the equivalent DevBar workflows were present in the shared pattern and were proactively corrected here:

1. Dependabot approval is now explicitly bound to `HEAD_SHA` through the pull-request review API.
2. Release version monotonicity is checked against the live default branch.
3. Existing release metadata is checked before fetching its tag.

A final CodeRabbit review was requested for the current architecture; no bot response or unresolved review thread is present.

## Validation

Final head: `9fd886357ba716818da55bd9848dd24a8b18b8b1`.

- CI run `30715899123`: success
- build, lint, package installation smoke, PostgreSQL, MySQL, MariaDB, SQLite, Better SQLite, and final `check-all` passed
- Dependabot-only run `30715899110`: skipped as expected for this owner-authored implementation PR
- no CodeRabbit inline review threads
- workflow YAML, shell syntax, JavaScript syntax, pinned Actions, responsibility separation, exact-head auto-merge, immutable tags, OIDC-only npm publication, and absence of check polling/destructive cleanup were statically validated

## Impact

After merge, default-branch pushes evaluate release preparation. A generated version PR is validated and queued through repository-controlled auto-merge. Its version-changing merge creates a GitHub Release from the exact version-introducing commit, and the resulting `release.published` event invokes the existing npm Trusted Publisher workflow. Owner-created manual GitHub Releases use the same npm path.

This implementation PR does not change `package.json`, cannot satisfy the release PR contract, and cannot create a tag, GitHub Release, or npm publication.

## Rollback

Revert this pull request. Existing release PRs, tags, GitHub Releases, and npm versions remain immutable external evidence and are not deleted.

No merge, tag, GitHub Release, npm publication, or deployment has been performed by this implementation.